### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/demandcast/utils/fetcher.py
+++ b/demandcast/utils/fetcher.py
@@ -345,24 +345,22 @@ def fetch_data(
             except (
                 requests.exceptions.HTTPError,
                 urllib.error.HTTPError,
-            ) as e:
+            ):
                 logging.error(
-                    f"HTTP error: {e}.\n"
-                    f"The URL {url} is not valid or the server is not "
-                    f"responding. Retrying ({attempt + 1}/{retries})..."
+                    "HTTP error while fetching remote data. "
+                    f"Retrying ({attempt + 1}/{retries})..."
                 )
                 time.sleep(retry_delay)
 
-    except (requests.exceptions.RequestException, urllib.error.URLError) as e:
+    except (requests.exceptions.RequestException, urllib.error.URLError):
         logging.error(
-            f"Request error: {e}.\n"
-            f"The URL {url} is not valid or the server is "
-            "not responding."
+            "Request error while fetching remote data. "
+            "The remote endpoint may be unavailable."
         )
-        raise Exception(f"Request error: {e}")
+        raise Exception("Request error while fetching remote data.")
 
     raise Exception(
-        f"Failed to fetch data from {url} after {retries} retries."
+        f"Failed to fetch remote data after {retries} retries."
     )
 
 

--- a/demandcast/utils/fetcher.py
+++ b/demandcast/utils/fetcher.py
@@ -359,9 +359,7 @@ def fetch_data(
         )
         raise Exception("Request error while fetching remote data.")
 
-    raise Exception(
-        f"Failed to fetch remote data after {retries} retries."
-    )
+    raise Exception(f"Failed to fetch remote data after {retries} retries.")
 
 
 def fetch_entsoe_demand(


### PR DESCRIPTION
Potential fix for [https://github.com/open-energy-transition/demandcast/security/code-scanning/4](https://github.com/open-energy-transition/demandcast/security/code-scanning/4)

General fix: never log or raise messages containing secrets (API keys/tokens/passwords), and avoid including raw request URLs when query strings can hold credentials.

Best fix here (without changing core functionality): in `demandcast/utils/fetcher.py`, replace sensitive log/exception messages in the shown error-handling region with sanitized, generic messages that keep retry/debug context but remove `{e}` and `{url}`. This preserves behavior (retry timing, control flow, exceptions) while preventing accidental secret disclosure via logs and raised exceptions.

Concretely, in the `fetch_data` function:
- Update the HTTP error log block to remove `{e}` and `{url}`.
- Update the outer request/URL error log block to remove `{e}` and `{url}`.
- Update `raise Exception(f"Request error: {e}")` to a generic `raise Exception("Request error while fetching remote data.")`.
- Update final failure `raise Exception(f"Failed to fetch data from {url} after {retries} retries.")` to avoid including URL.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
