### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     timeout-minutes: 10


### PR DESCRIPTION
Potential fix for [https://github.com/open-energy-transition/demandcast/security/code-scanning/2](https://github.com/open-energy-transition/demandcast/security/code-scanning/2)

Add an explicit workflow-level `permissions` block with the minimum required scope, so all jobs inherit it unless overridden.  
For this workflow, the best non-functional-change fix is:

- In `.github/workflows/ci.yml`, insert at the workflow root (after `concurrency` and before `jobs`) :
  - `permissions:`
  - `contents: read`

Why this is best: both jobs only need to check out code and run local checks/tests; `contents: read` is sufficient for `actions/checkout` and avoids granting write access. A root-level block is concise and applies consistently across both jobs.

No imports/methods/definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
