### PR TITLE
Fix for File is not always closed

### DIFF
--- a/demandcast/checks/data_availability.py
+++ b/demandcast/checks/data_availability.py
@@ -247,16 +247,17 @@ def run_check() -> None:
 
     # Read codes available for future electricity demand per capita
     # projections from the IIASA SSP database.
-    iiasa_future_electricity_demand_per_capita_mapping = yaml.safe_load(
-        open(
-            os.path.join(
-                retrievals_directory,
-                "socio_economic_data_sources",
-                "iam_regions_mapping.yaml",
-            ),
-            "r",
+    with open(
+        os.path.join(
+            retrievals_directory,
+            "socio_economic_data_sources",
+            "iam_regions_mapping.yaml",
+        ),
+        "r",
+    ) as iiasa_mapping_file:
+        iiasa_future_electricity_demand_per_capita_mapping = yaml.safe_load(
+            iiasa_mapping_file
         )
-    )
     iiasa_future_electricity_demand_per_capita_codes = [
         code
         for code, __ in iiasa_future_electricity_demand_per_capita_mapping.items()


### PR DESCRIPTION
Use a context manager for reading the YAML file and pass the opened handle to `yaml.safe_load`. This preserves behavior while guaranteeing the file is always closed.

**Where to change:**  
`demandcast/checks/data_availability.py`, around lines 250–259 (the YAML mapping load).

**What to change:**
- Replace the inline `yaml.safe_load(open(...))` call with:
  1. `with open(..., "r") as mapping_file:`
  2. `iiasa_future_electricity_demand_per_capita_mapping = yaml.safe_load(mapping_file)`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._