### PR TITLE
feat: add LSTM as optional forecasting algorithm (#133)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 
 # macOS
 .DS_Store
-.claude/ 
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 
 # macOS
 .DS_Store
+.claude/ 

--- a/demandcast/benchmark_retrieve.ps1
+++ b/demandcast/benchmark_retrieve.ps1
@@ -1,7 +1,14 @@
 ﻿# benchmark_retrieve.ps1 — fail-fast retrieval for DNK/AUT/PRT 2021-2023
+#
+# Runs the electricity/annual-elec/population/gdp/temperature
+# retrieval steps followed by assemble, in order, aborting on the
+# first non-zero exit code. Reproduce by running this script from
+# any location; it locates the `demandcast/` package root relative
+# to its own file path so no hardcoded machine-specific path is
+# needed.
 # Monitor: Get-Content -Wait logs\benchmark_orchestration.log
 
-Set-Location "C:\Users\Dell\Desktop\DemandCast\demandcast\demandcast"
+Set-Location $PSScriptRoot
 
 New-Item -ItemType Directory -Force -Path "logs" | Out-Null
 $MasterLog = "logs\benchmark_orchestration.log"

--- a/demandcast/benchmark_retrieve.ps1
+++ b/demandcast/benchmark_retrieve.ps1
@@ -1,0 +1,53 @@
+﻿# benchmark_retrieve.ps1 — fail-fast retrieval for DNK/AUT/PRT 2021-2023
+# Monitor: Get-Content -Wait logs\benchmark_orchestration.log
+
+Set-Location "C:\Users\Dell\Desktop\DemandCast\demandcast\demandcast"
+
+New-Item -ItemType Directory -Force -Path "logs" | Out-Null
+$MasterLog = "logs\benchmark_orchestration.log"
+
+function Log([string]$msg) {
+    $line = (Get-Date -Format "yyyy-MM-dd HH:mm:ss") + "  " + $msg
+    Write-Host $line
+    Add-Content -Path $MasterLog -Value $line
+}
+
+function Run-Step([string]$Desc, [string]$Config, [string]$Script = "retrieve.py") {
+    Log ("--- STARTING  " + $Desc + " ---")
+    $t0 = Get-Date
+
+    uv run $Script --config $Config
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        Log ("--- FAILED    " + $Desc + "  (exit " + $exitCode + ") ---")
+        Log "ABORTED -- check logs\ directory for per-step log files."
+        exit 1
+    }
+
+    $mins = [int]((Get-Date) - $t0).TotalMinutes
+    Log ("--- DONE      " + $Desc + "  (" + $mins + "m) ---")
+}
+
+Log "=========================================================="
+Log "Benchmark retrieval START"
+Log "  Entities : DNK, AUT, PRT"
+Log "  Years    : 2021-2023"
+Log "  Steps    : electricity / annual-elec / population / gdp / temperature / assemble"
+Log "=========================================================="
+
+Run-Step "1/6  electricity demand (ENTSO-E)"         "config\benchmark_retrieve_electricity.yaml"
+Run-Step "2/6  annual electricity demand per capita" "config\benchmark_retrieve_annual_elec.yaml"
+Run-Step "3/6  population"                           "config\benchmark_retrieve_population.yaml"
+Run-Step "4/6  GDP PPP per capita"                   "config\benchmark_retrieve_gdp.yaml"
+
+Log "--- NOTE  Steps 1-4 complete. Step 5 issues up to 15 CDS API requests ---"
+Log "---       (ERA5 for years 2020-2024, 3 entities). Expect 4-8 h.       ---"
+
+Run-Step "5/6  temperature 2021-2023  (ERA5 via CDS)" "config\benchmark_retrieve_temperature.yaml"
+Run-Step "6/6  assemble"                              "config\benchmark_assemble.yaml" "assemble.py"
+
+Log "=========================================================="
+Log "Benchmark retrieval COMPLETE"
+Log "Assembled dataset written to: data\assembled\"
+Log "=========================================================="

--- a/demandcast/benchmark_retrieve_resume.ps1
+++ b/demandcast/benchmark_retrieve_resume.ps1
@@ -1,8 +1,12 @@
 # benchmark_retrieve_resume.ps1 — resume from step 5/6 only
-# Steps 1-4 already completed; this runs temperature (ERA5) + assemble.
+#
+# Steps 1-4 already completed; this runs temperature (ERA5) +
+# assemble only. Reproduce by running this script from any location;
+# it locates the `demandcast/` package root relative to its own file
+# path so no hardcoded machine-specific path is needed.
 # Monitor: Get-Content -Wait logs\benchmark_orchestration.log
 
-Set-Location "C:\Users\Dell\Desktop\DemandCast\demandcast\demandcast"
+Set-Location $PSScriptRoot
 
 New-Item -ItemType Directory -Force -Path "logs" | Out-Null
 $MasterLog = "logs\benchmark_orchestration.log"

--- a/demandcast/benchmark_retrieve_resume.ps1
+++ b/demandcast/benchmark_retrieve_resume.ps1
@@ -1,0 +1,46 @@
+# benchmark_retrieve_resume.ps1 — resume from step 5/6 only
+# Steps 1-4 already completed; this runs temperature (ERA5) + assemble.
+# Monitor: Get-Content -Wait logs\benchmark_orchestration.log
+
+Set-Location "C:\Users\Dell\Desktop\DemandCast\demandcast\demandcast"
+
+New-Item -ItemType Directory -Force -Path "logs" | Out-Null
+$MasterLog = "logs\benchmark_orchestration.log"
+
+function Log([string]$msg) {
+    $line = (Get-Date -Format "yyyy-MM-dd HH:mm:ss") + "  " + $msg
+    Write-Host $line
+    Add-Content -Path $MasterLog -Value $line
+}
+
+function Run-Step([string]$Desc, [string]$Config, [string]$Script = "retrieve.py") {
+    Log ("--- STARTING  " + $Desc + " ---")
+    $t0 = Get-Date
+
+    uv run $Script --config $Config
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        Log ("--- FAILED    " + $Desc + "  (exit " + $exitCode + ") ---")
+        Log "ABORTED -- check logs\ directory for per-step log files."
+        exit 1
+    }
+
+    $mins = [int]((Get-Date) - $t0).TotalMinutes
+    Log ("--- DONE      " + $Desc + "  (" + $mins + "m) ---")
+}
+
+Log "=========================================================="
+Log "Benchmark retrieval RESUME (steps 5-6 only)"
+Log "  Entities : DNK, AUT, PRT"
+Log "  Years    : 2021-2023"
+Log "  Note     : ERA5 licence accepted; resuming after step 4"
+Log "=========================================================="
+
+Run-Step "5/6  temperature 2021-2023  (ERA5 via CDS)" "config\benchmark_retrieve_temperature.yaml"
+Run-Step "6/6  assemble"                              "config\benchmark_assemble.yaml" "assemble.py"
+
+Log "=========================================================="
+Log "Benchmark retrieval COMPLETE"
+Log "Assembled dataset written to: data\assembled\"
+Log "=========================================================="

--- a/demandcast/config/benchmark_assemble.yaml
+++ b/demandcast/config/benchmark_assemble.yaml
@@ -1,0 +1,9 @@
+target_use: training
+file: config/benchmark_codes.yaml
+start_year: 2021
+end_year: 2023
+scenario_for_annual_electricity_demand_per_capita:
+scenario_for_gdp_ppp_per_capita:
+scenario_for_population:
+scenario_for_temperature:
+climate_model_for_temperature:

--- a/demandcast/config/benchmark_codes.yaml
+++ b/demandcast/config/benchmark_codes.yaml
@@ -1,0 +1,7 @@
+entities:
+  - country_name: Denmark
+    country_code: DNK
+  - country_name: Austria
+    country_code: AUT
+  - country_name: Portugal
+    country_code: PRT

--- a/demandcast/config/benchmark_retrieve_annual_elec.yaml
+++ b/demandcast/config/benchmark_retrieve_annual_elec.yaml
@@ -1,0 +1,10 @@
+variable: annual_electricity_demand_per_capita
+electricity_data_source:
+code:
+file: config/benchmark_codes.yaml
+year:
+start_year:
+end_year:
+scenario:
+weather_variable:
+climate_model:

--- a/demandcast/config/benchmark_retrieve_electricity.yaml
+++ b/demandcast/config/benchmark_retrieve_electricity.yaml
@@ -1,0 +1,10 @@
+variable: electricity_demand
+electricity_data_source: entsoe
+code:
+file: config/benchmark_codes.yaml
+year:
+start_year:
+end_year:
+scenario:
+weather_variable:
+climate_model:

--- a/demandcast/config/benchmark_retrieve_gdp.yaml
+++ b/demandcast/config/benchmark_retrieve_gdp.yaml
@@ -1,0 +1,10 @@
+variable: gdp_ppp_per_capita
+electricity_data_source:
+code:
+file: config/benchmark_codes.yaml
+year:
+start_year:
+end_year:
+scenario:
+weather_variable:
+climate_model:

--- a/demandcast/config/benchmark_retrieve_population.yaml
+++ b/demandcast/config/benchmark_retrieve_population.yaml
@@ -1,0 +1,10 @@
+variable: population
+electricity_data_source:
+code:
+file: config/benchmark_codes.yaml
+year:
+start_year:
+end_year:
+scenario:
+weather_variable:
+climate_model:

--- a/demandcast/config/benchmark_retrieve_temperature.yaml
+++ b/demandcast/config/benchmark_retrieve_temperature.yaml
@@ -1,0 +1,10 @@
+variable: temperature
+electricity_data_source:
+code:
+file: config/benchmark_codes.yaml
+year:
+start_year: 2021
+end_year: 2023
+scenario:
+weather_variable:
+climate_model:

--- a/demandcast/config/lstm_config.yaml
+++ b/demandcast/config/lstm_config.yaml
@@ -1,0 +1,38 @@
+# Configuration for the LSTM model.
+
+# REQUIRED.
+# Lookback window length in timesteps. Each prediction draws on the
+# preceding n_timesteps rows of the same entity.
+n_timesteps: 24
+
+# REQUIRED.
+# Number of LSTM hidden units per layer. Smaller values train faster
+# on CPU.
+n_units: 32
+
+# REQUIRED.
+# Number of stacked LSTM layers. Dropout only takes effect when
+# n_layers > 1.
+n_layers: 1
+
+# REQUIRED.
+# Dropout rate applied between LSTM layers (0.0 = disabled). Only
+# meaningful when n_layers > 1.
+dropout: 0.0
+
+# REQUIRED.
+# Number of full passes over the training data. Increase for better
+# accuracy at the cost of training time.
+epochs: 5
+
+# REQUIRED.
+# Mini-batch size used for both training and inference.
+batch_size: 256
+
+# REQUIRED.
+# Adam optimiser learning rate.
+learning_rate: 0.001
+
+# REQUIRED.
+# Random seed passed to torch.manual_seed for reproducibility.
+random_state: 42

--- a/demandcast/cross_validate.py
+++ b/demandcast/cross_validate.py
@@ -13,6 +13,7 @@ import logging
 import os
 from typing import Optional
 
+import ml_models.lstm
 import ml_models.xgboost
 import pandas
 import utils.config
@@ -95,13 +96,15 @@ def _cross_validate(
     """
     # Get an initialized model.
     if algorithm.lower() == "xgboost":
-        xgb_model = ml_models.xgboost.get_initialized_model()
+        model = ml_models.xgboost.get_initialized_model()
+    elif algorithm.lower() == "lstm":
+        model = ml_models.lstm.get_initialized_model()
     else:
         raise ValueError(f"Unsupported algorithm: {algorithm}")
 
     # Perform Leave-One-Group-Out cross-validation
     cv_results = cross_validate(
-        xgb_model,
+        model,
         prepared_dataset["features"],
         prepared_dataset["target"],
         groups=prepared_dataset["group"],

--- a/demandcast/cross_validate.py
+++ b/demandcast/cross_validate.py
@@ -19,6 +19,8 @@ import pandas
 import utils.config
 import utils.ml
 from pydantic import BaseModel, ValidationError
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.metrics import get_scorer
 from sklearn.model_selection import LeaveOneGroupOut, cross_validate
 
 
@@ -63,14 +65,38 @@ def _read_and_check_configuration() -> BaseModel:
         raise ValueError(f"Configuration validation error: {e}") from e
 
 
-def _cross_validate(
+def _log_mape_summary(mapes: pandas.DataFrame) -> None:
+    """
+    Log average, median, and standard deviation of MAPE values.
+
+    Parameters
+    ----------
+    mapes : pandas.DataFrame
+        DataFrame with "Training MAPE" and "Testing MAPE" columns.
+    """
+    logging.info("Training set:")
+    logging.info(f" - Average MAPE: {mapes['Training MAPE'].mean():.4f}")
+    logging.info(f" - Median MAPE: {mapes['Training MAPE'].median():.4f}")
+    logging.info(f" - Std MAPE: {mapes['Training MAPE'].std():.4f}")
+    logging.info("Testing set:")
+    logging.info(f" - Average MAPE: {mapes['Testing MAPE'].mean():.4f}")
+    logging.info(f" - Median MAPE: {mapes['Testing MAPE'].median():.4f}")
+    logging.info(f" - Std MAPE: {mapes['Testing MAPE'].std():.4f}")
+
+
+def _cross_validate_xgboost(
     prepared_dataset: dict[str, pandas.DataFrame],
     scoring_metric: str,
     n_jobs: int,
-    algorithm: str,
 ) -> pandas.DataFrame:
     """
-    Run cross-validation for the specified machine learning model.
+    Run Leave-One-Group-Out cross-validation for XGBoost.
+
+    Uses sklearn's ``cross_validate()`` directly. This is safe for
+    XGBoost because its ``fit()``/``predict()`` calls do not depend
+    on entity ``groups`` — unlike the LSTM, whose sequence
+    construction must respect entity boundaries and therefore cannot
+    go through ``cross_validate()`` (see ``_cross_validate_lstm``).
 
     Parameters
     ----------
@@ -81,26 +107,13 @@ def _cross_validate(
         The scoring metric to use for evaluation.
     n_jobs : int
         The number of parallel jobs to run.
-    algorithm : str
-        The machine learning algorithm to use.
 
     Returns
     -------
     mapes : pandas.DataFrame
         DataFrame containing MAPE values for each entity.
-
-    Raises
-    ------
-    ValueError
-        If an unsupported algorithm is specified.
     """
-    # Get an initialized model.
-    if algorithm.lower() == "xgboost":
-        model = ml_models.xgboost.get_initialized_model()
-    elif algorithm.lower() == "lstm":
-        model = ml_models.lstm.get_initialized_model()
-    else:
-        raise ValueError(f"Unsupported algorithm: {algorithm}")
+    model = ml_models.xgboost.get_initialized_model()
 
     # Perform Leave-One-Group-Out cross-validation
     cv_results = cross_validate(
@@ -133,16 +146,175 @@ def _cross_validate(
     mapes["Training MAPE"] = -cv_results["train_score"]
     mapes["Testing MAPE"] = -cv_results["test_score"]
 
-    logging.info("Training set:")
-    logging.info(f" - Average MAPE: {mapes['Training MAPE'].mean():.4f}")
-    logging.info(f" - Median MAPE: {mapes['Training MAPE'].median():.4f}")
-    logging.info(f" - Std MAPE: {mapes['Training MAPE'].std():.4f}")
-    logging.info("Testing set:")
-    logging.info(f" - Average MAPE: {mapes['Testing MAPE'].mean():.4f}")
-    logging.info(f" - Median MAPE: {mapes['Testing MAPE'].median():.4f}")
-    logging.info(f" - Std MAPE: {mapes['Testing MAPE'].std():.4f}")
+    _log_mape_summary(mapes)
 
     return mapes
+
+
+class _GroupAwareLSTM(BaseEstimator, RegressorMixin):
+    """
+    Adapt a fitted LSTM model for sklearn scorers.
+
+    A scorer obtained from ``sklearn.metrics.get_scorer()`` calls
+    ``estimator.predict(X)`` with no way to pass entity ``groups``
+    alongside ``X``. This wrapper closes over the group labels for a
+    specific fold/split so that predictions still respect entity
+    boundaries, while routing every prediction through
+    ``ml_models.lstm.predict()``. Inherits from ``BaseEstimator`` and
+    ``RegressorMixin`` only so sklearn's scorer machinery recognises
+    it as a fitted regressor.
+    """
+
+    def __init__(
+        self,
+        lstm_model: ml_models.lstm.LSTMRegressor,
+        group: pandas.Series,
+    ) -> None:
+        self.lstm_model = lstm_model
+        self.group = group
+
+    def predict(self, features: pandas.DataFrame) -> pandas.Series:
+        """
+        Predict target values for ``features``.
+
+        Parameters
+        ----------
+        features : pandas.DataFrame
+            Feature rows to predict on. Must align row-for-row with
+            the ``group`` labels this wrapper was built with.
+
+        Returns
+        -------
+        pandas.Series
+            Predicted values, one per row of ``features``.
+        """
+        return ml_models.lstm.predict(
+            self.lstm_model,
+            {"features": features, "group": self.group},
+        )
+
+
+def _cross_validate_lstm(
+    prepared_dataset: dict[str, pandas.DataFrame],
+    scoring_metric: str,
+) -> pandas.DataFrame:
+    """
+    Run manual Leave-One-Group-Out cross-validation for the LSTM.
+
+    sklearn's ``cross_validate()`` never forwards ``groups`` into
+    ``estimator.fit()``, so using it for the LSTM would silently let
+    it build sequences across country boundaries during
+    cross-validation (``groups`` would be ``None`` inside ``fit()``).
+    This function instead builds LOGO folds by hand with
+    ``LeaveOneGroupOut().split()`` and calls ``ml_models.lstm.train()``
+    and ``ml_models.lstm.predict()`` directly for each fold, so
+    group boundaries are always respected.
+
+    Parameters
+    ----------
+    prepared_dataset : dict[str, pandas.DataFrame]
+        A dictionary containing prepared features, target, and entity
+        codes.
+    scoring_metric : str
+        The scoring metric to use for evaluation.
+
+    Returns
+    -------
+    mapes : pandas.DataFrame
+        DataFrame containing MAPE values for each entity.
+    """
+    scorer = get_scorer(scoring_metric)
+
+    features = prepared_dataset["features"]
+    target = prepared_dataset["target"]
+    group = prepared_dataset["group"]
+
+    list_entity_codes = []
+    train_scores = []
+    test_scores = []
+
+    for train_index, test_index in LeaveOneGroupOut().split(
+        features, target, group
+    ):
+        fold_dataset = {
+            "training": {
+                "features": features.iloc[train_index],
+                "target": target.iloc[train_index],
+                "group": group.iloc[train_index],
+            }
+        }
+        lstm_model = ml_models.lstm.train(fold_dataset)
+
+        train_scores.append(
+            scorer(
+                _GroupAwareLSTM(lstm_model, group.iloc[train_index]),
+                features.iloc[train_index],
+                target.iloc[train_index],
+            )
+        )
+        test_scores.append(
+            scorer(
+                _GroupAwareLSTM(lstm_model, group.iloc[test_index]),
+                features.iloc[test_index],
+                target.iloc[test_index],
+            )
+        )
+        list_entity_codes.append(group.iloc[test_index[0]])
+
+    logging.info("Cross-validation completed successfully.")
+
+    # Initialize a DataFrame to store mapes.
+    mapes = pandas.DataFrame()
+    mapes["Entity Code"] = list_entity_codes
+
+    # Add train and test scores to the results DataFrame.
+    mapes["Training MAPE"] = -pandas.Series(train_scores)
+    mapes["Testing MAPE"] = -pandas.Series(test_scores)
+
+    _log_mape_summary(mapes)
+
+    return mapes
+
+
+def _cross_validate(
+    prepared_dataset: dict[str, pandas.DataFrame],
+    scoring_metric: str,
+    n_jobs: int,
+    algorithm: str,
+) -> pandas.DataFrame:
+    """
+    Run cross-validation for the specified machine learning model.
+
+    Parameters
+    ----------
+    prepared_dataset : dict[str, pandas.DataFrame]
+        A dictionary containing prepared features, target, and entity
+        codes.
+    scoring_metric : str
+        The scoring metric to use for evaluation.
+    n_jobs : int
+        The number of parallel jobs to run.
+    algorithm : str
+        The machine learning algorithm to use.
+
+    Returns
+    -------
+    mapes : pandas.DataFrame
+        DataFrame containing MAPE values for each entity.
+
+    Raises
+    ------
+    ValueError
+        If an unsupported algorithm is specified.
+    """
+    if algorithm.lower() == "xgboost":
+        return _cross_validate_xgboost(
+            prepared_dataset, scoring_metric, n_jobs
+        )
+    elif algorithm.lower() == "lstm":
+        return _cross_validate_lstm(prepared_dataset, scoring_metric)
+    else:
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
 
 
 def run_model_cross_validation(

--- a/demandcast/forecast.py
+++ b/demandcast/forecast.py
@@ -13,6 +13,7 @@ import logging
 import os
 from typing import Optional
 
+import ml_models.lstm
 import ml_models.xgboost
 import pandas
 import utils.config
@@ -164,6 +165,30 @@ def run_forecasting(
 
         # Make predictions.
         predictions = ml_models.xgboost.predict(model, prepared_dataset)
+
+        logging.info("Forecasting completed successfully.")
+
+    elif algorithm.lower() == "lstm":
+        # Get the trained model path.
+        trained_model_path = utils.ml.get_trained_model_path(
+            model_path, algorithm.lower(), extension=".pt"
+        )
+
+        # Load the trained model.
+        model = ml_models.lstm.load(trained_model_path)
+
+        # Check that the model was trained with the same features of the
+        # prepared dataset.
+        data_features = prepared_dataset["features"].columns.tolist()
+        model_features = model.feature_names_in_.tolist()
+        if data_features != model_features:
+            raise ValueError(
+                "The features used in the prepared dataset do not match "
+                "those used during model training."
+            )
+
+        # Make predictions.
+        predictions = ml_models.lstm.predict(model, prepared_dataset)
 
         logging.info("Forecasting completed successfully.")
 

--- a/demandcast/ml_models/lstm.py
+++ b/demandcast/ml_models/lstm.py
@@ -32,22 +32,21 @@ if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
         if os.path.isdir(_torch_lib):
             _dll_dir_tokens.append(os.add_dll_directory(_torch_lib))
             break
-import numpy as np
-import torch
-import torch.nn as nn
-import pandas
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+import torch.nn as nn  # noqa: E402
+import pandas  # noqa: E402
+
 # isort: on
-import yaml
-from pydantic import BaseModel, ValidationError
-from sklearn.base import BaseEstimator, RegressorMixin
-from sklearn.utils.validation import check_is_fitted
+import utils.config  # noqa: E402
+import yaml  # noqa: E402
+from pydantic import BaseModel, ValidationError  # noqa: E402
+from sklearn.base import BaseEstimator, RegressorMixin  # noqa: E402
+from sklearn.utils.validation import check_is_fitted  # noqa: E402
 
-import utils.config
-
-
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Private PyTorch network
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 class _LSTMNet(nn.Module):
@@ -90,9 +89,9 @@ class _LSTMNet(nn.Module):
         return self.fc(out[:, -1, :]).squeeze(-1)
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # sklearn-compatible wrapper
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 class LSTMRegressor(BaseEstimator, RegressorMixin):
@@ -182,9 +181,7 @@ class LSTMRegressor(BaseEstimator, RegressorMixin):
         n_samples, n_features = X.shape
 
         if groups is None:
-            pad = np.zeros(
-                (self.n_timesteps - 1, n_features), dtype=X.dtype
-            )
+            pad = np.zeros((self.n_timesteps - 1, n_features), dtype=X.dtype)
             X_padded = np.concatenate([pad, X], axis=0)
             idx = (
                 np.arange(n_samples)[:, None]
@@ -206,9 +203,7 @@ class LSTMRegressor(BaseEstimator, RegressorMixin):
         for i in range(n_samples):
             window_start = max(run_start[i], i - self.n_timesteps + 1)
             n_valid = i - window_start + 1
-            X_seq[i, self.n_timesteps - n_valid :] = X[
-                window_start : i + 1
-            ]
+            X_seq[i, self.n_timesteps - n_valid :] = X[window_start : i + 1]
         return X_seq
 
     # ------------------------------------------------------------------
@@ -324,9 +319,9 @@ class LSTMRegressor(BaseEstimator, RegressorMixin):
     # get_params() and set_params() are inherited from BaseEstimator.
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Module-level API  (mirrors ml_models/xgboost.py)
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def _read_configuration() -> BaseModel:
@@ -365,9 +360,7 @@ def _read_configuration() -> BaseModel:
     try:
         return ConfigModel(**raw_config)
     except ValidationError as e:
-        raise ValueError(
-            f"Configuration validation error: {e}"
-        ) from e
+        raise ValueError(f"Configuration validation error: {e}") from e
 
 
 def load(model_path: str) -> LSTMRegressor:
@@ -390,9 +383,7 @@ def load(model_path: str) -> LSTMRegressor:
         If ``model_path`` does not exist.
     """
     if not os.path.exists(model_path):
-        raise FileNotFoundError(
-            f"Model checkpoint not found: {model_path}"
-        )
+        raise FileNotFoundError(f"Model checkpoint not found: {model_path}")
 
     checkpoint = torch.load(model_path, weights_only=False)
 
@@ -443,9 +434,7 @@ def save(lstm_model: LSTMRegressor, model_name: str) -> None:
         "state_dict": lstm_model.net_.state_dict(),
     }
     if hasattr(lstm_model, "feature_names_in_"):
-        checkpoint["feature_names_in_"] = (
-            lstm_model.feature_names_in_.tolist()
-        )
+        checkpoint["feature_names_in_"] = lstm_model.feature_names_in_.tolist()
 
     torch.save(checkpoint, output_path)
 
@@ -480,9 +469,7 @@ def get_initialized_model() -> LSTMRegressor:
 
 
 def train(
-    prepared_dataset: dict[
-        str, dict[str, pandas.DataFrame | pandas.Series]
-    ],
+    prepared_dataset: dict[str, dict[str, pandas.DataFrame | pandas.Series]],
 ) -> LSTMRegressor:
     """
     Train an LSTM model on the prepared dataset.
@@ -575,7 +562,6 @@ def predict(
         )
         predictions[split_name] = pandas.Series(preds)
         logging.info(
-            f"Predictions made for {split_name} set: "
-            f"{len(preds)} records."
+            f"Predictions made for {split_name} set: {len(preds)} records."
         )
     return predictions

--- a/demandcast/ml_models/lstm.py
+++ b/demandcast/ml_models/lstm.py
@@ -1,0 +1,581 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    This module contains functions to train and save an LSTM model
+    for electricity demand forecasting. The ``LSTMRegressor`` wrapper
+    implements the sklearn estimator interface, enabling direct use
+    with ``cross_validate()`` and ``LeaveOneGroupOut()``.
+
+    Sequence construction respects entity boundaries: rows from
+    different entities (identified by the ``"group"`` column of the
+    prepared dataset) never share a lookback window.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+# isort: off
+# Windows: CPython GC calls RemoveDllDirectory when the token from
+# add_dll_directory is collected; storing the token prevents removal.
+# torch must be imported before pandas — pandas side-effects corrupt
+# the Windows DLL loader state for torch's c10.dll initialisation.
+_dll_dir_tokens: list = []
+if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+    for _sp in sys.path:
+        _torch_lib = os.path.join(_sp, "torch", "lib")
+        if os.path.isdir(_torch_lib):
+            _dll_dir_tokens.append(os.add_dll_directory(_torch_lib))
+            break
+import numpy as np
+import torch
+import torch.nn as nn
+import pandas
+# isort: on
+import yaml
+from pydantic import BaseModel, ValidationError
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.utils.validation import check_is_fitted
+
+import utils.config
+
+
+# ---------------------------------------------------------------------------
+# Private PyTorch network
+# ---------------------------------------------------------------------------
+
+
+class _LSTMNet(nn.Module):
+    """Stacked LSTM with a single linear output layer."""
+
+    def __init__(
+        self,
+        n_features: int,
+        n_units: int,
+        n_layers: int,
+        dropout: float,
+    ) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(
+            input_size=n_features,
+            hidden_size=n_units,
+            num_layers=n_layers,
+            batch_first=True,
+            # Dropout is applied between layers only; ignored for
+            # single-layer networks.
+            dropout=dropout if n_layers > 1 else 0.0,
+        )
+        self.fc = nn.Linear(n_units, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Compute a forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``(batch, n_timesteps, n_features)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Shape ``(batch,)`` — one scalar per sample.
+        """
+        out, _ = self.lstm(x)
+        return self.fc(out[:, -1, :]).squeeze(-1)
+
+
+# ---------------------------------------------------------------------------
+# sklearn-compatible wrapper
+# ---------------------------------------------------------------------------
+
+
+class LSTMRegressor(BaseEstimator, RegressorMixin):
+    """
+    LSTM regressor with an sklearn-compatible interface.
+
+    Uses a PyTorch ``nn.LSTM`` backend. Compatible with
+    ``sklearn.model_selection.cross_validate`` and
+    ``LeaveOneGroupOut``.
+
+    Parameters
+    ----------
+    n_timesteps : int
+        Lookback window length. Zero-padding (or group-boundary
+        padding when ``groups`` is supplied) ensures that every
+        sample maps to exactly one prediction.
+    n_units : int
+        LSTM hidden units per layer.
+    n_layers : int
+        Number of stacked LSTM layers.
+    dropout : float
+        Dropout rate between LSTM layers (meaningful only when
+        ``n_layers > 1``).
+    epochs : int
+        Training epochs over the full dataset.
+    batch_size : int
+        Mini-batch size used for training and inference.
+    learning_rate : float
+        Adam optimiser learning rate.
+    random_state : int
+        Seed passed to ``torch.manual_seed`` for reproducibility.
+    """
+
+    def __init__(
+        self,
+        n_timesteps: int = 24,
+        n_units: int = 32,
+        n_layers: int = 1,
+        dropout: float = 0.0,
+        epochs: int = 5,
+        batch_size: int = 256,
+        learning_rate: float = 1e-3,
+        random_state: int = 42,
+    ) -> None:
+        # sklearn convention: store constructor args unchanged.
+        self.n_timesteps = n_timesteps
+        self.n_units = n_units
+        self.n_layers = n_layers
+        self.dropout = dropout
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.learning_rate = learning_rate
+        self.random_state = random_state
+
+    # ------------------------------------------------------------------
+    # Sequence construction
+    # ------------------------------------------------------------------
+
+    def _make_sequences(
+        self,
+        X: np.ndarray,
+        groups: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """
+        Build ``(n_samples, n_timesteps, n_features)`` sequences.
+
+        Without groups, prepends ``n_timesteps - 1`` zero rows so
+        every sample maps to exactly one output. With groups, sequences
+        never cross entity boundaries: zero-padding is inserted at the
+        start of each new contiguous run instead of borrowing rows from
+        the preceding entity.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Shape ``(n_samples, n_features)``.
+        groups : np.ndarray or None
+            Entity label per row. Only contiguous run boundaries are
+            treated as entity boundaries; non-contiguous recurrence of
+            a label starts a fresh run.
+
+        Returns
+        -------
+        np.ndarray
+            Shape ``(n_samples, n_timesteps, n_features)``.
+        """
+        n_samples, n_features = X.shape
+
+        if groups is None:
+            pad = np.zeros(
+                (self.n_timesteps - 1, n_features), dtype=X.dtype
+            )
+            X_padded = np.concatenate([pad, X], axis=0)
+            idx = (
+                np.arange(n_samples)[:, None]
+                + np.arange(self.n_timesteps)[None, :]
+            )
+            return X_padded[idx]
+
+        groups = np.asarray(groups)
+        run_start = np.empty(n_samples, dtype=int)
+        run_start[0] = 0
+        for i in range(1, n_samples):
+            run_start[i] = (
+                i if groups[i] != groups[i - 1] else run_start[i - 1]
+            )
+
+        X_seq = np.zeros(
+            (n_samples, self.n_timesteps, n_features), dtype=X.dtype
+        )
+        for i in range(n_samples):
+            window_start = max(run_start[i], i - self.n_timesteps + 1)
+            n_valid = i - window_start + 1
+            X_seq[i, self.n_timesteps - n_valid :] = X[
+                window_start : i + 1
+            ]
+        return X_seq
+
+    # ------------------------------------------------------------------
+    # sklearn estimator interface
+    # ------------------------------------------------------------------
+
+    def fit(
+        self,
+        X: pandas.DataFrame | np.ndarray,
+        y: pandas.Series | np.ndarray,
+        groups: pandas.Series | np.ndarray | None = None,
+    ) -> LSTMRegressor:
+        """
+        Fit the LSTM model.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame or np.ndarray of shape \
+(n_samples, n_features)
+            Training features. Column names are stored in
+            ``feature_names_in_`` when X is a DataFrame.
+        y : pandas.Series or np.ndarray of shape (n_samples,)
+            Target values.
+        groups : array-like of shape (n_samples,), optional
+            Entity labels per row. When supplied, sequences are
+            built without crossing group boundaries.
+
+        Returns
+        -------
+        LSTMRegressor
+            This estimator.
+        """
+        if hasattr(X, "columns"):
+            self.feature_names_in_ = np.array(X.columns.tolist())
+
+        X_arr = np.array(X, dtype=np.float32)
+        y_arr = np.array(y, dtype=np.float32).ravel()
+        self.n_features_in_ = X_arr.shape[1]
+
+        groups_arr = np.asarray(groups) if groups is not None else None
+        X_seq = self._make_sequences(X_arr, groups_arr)
+
+        torch.manual_seed(self.random_state)
+        self.net_ = _LSTMNet(
+            self.n_features_in_,
+            self.n_units,
+            self.n_layers,
+            self.dropout,
+        )
+        optimizer = torch.optim.Adam(
+            self.net_.parameters(), lr=self.learning_rate
+        )
+        criterion = nn.MSELoss()
+
+        dataset = torch.utils.data.TensorDataset(
+            torch.from_numpy(X_seq), torch.from_numpy(y_arr)
+        )
+        loader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            generator=torch.Generator().manual_seed(self.random_state),
+        )
+
+        self.net_.train()
+        for _ in range(self.epochs):
+            for X_batch, y_batch in loader:
+                optimizer.zero_grad()
+                loss = criterion(self.net_(X_batch), y_batch)
+                loss.backward()
+                optimizer.step()
+
+        self.net_.eval()
+        return self
+
+    def predict(
+        self,
+        X: pandas.DataFrame | np.ndarray,
+        groups: pandas.Series | np.ndarray | None = None,
+    ) -> np.ndarray:
+        """
+        Predict with the trained LSTM.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame or np.ndarray of shape \
+(n_samples, n_features)
+            Input features.
+        groups : array-like of shape (n_samples,), optional
+            Entity labels. Pass the same groups used in ``fit`` to
+            apply entity-boundary padding during inference.
+
+        Returns
+        -------
+        np.ndarray
+            Shape ``(n_samples,)`` — one prediction per row.
+        """
+        check_is_fitted(self, "net_")
+
+        X_arr = np.array(X, dtype=np.float32)
+        groups_arr = np.asarray(groups) if groups is not None else None
+        X_seq = self._make_sequences(X_arr, groups_arr)
+        X_tensor = torch.from_numpy(X_seq)
+
+        self.net_.eval()
+        parts: list[np.ndarray] = []
+        with torch.no_grad():
+            for i in range(0, len(X_tensor), self.batch_size):
+                batch = X_tensor[i : i + self.batch_size]
+                parts.append(self.net_(batch).numpy())
+        return np.concatenate(parts).flatten()
+
+    # get_params() and set_params() are inherited from BaseEstimator.
+
+
+# ---------------------------------------------------------------------------
+# Module-level API  (mirrors ml_models/xgboost.py)
+# ---------------------------------------------------------------------------
+
+
+def _read_configuration() -> BaseModel:
+    """
+    Read and validate the LSTM configuration file.
+
+    Returns
+    -------
+    BaseModel
+        Validated configuration model with all LSTM hyperparameters.
+
+    Raises
+    ------
+    ValueError
+        If the configuration file contains invalid values.
+    """
+
+    class ConfigModel(BaseModel):
+        n_timesteps: int = 24
+        n_units: int = 32
+        n_layers: int = 1
+        dropout: float = 0.0
+        epochs: int = 5
+        batch_size: int = 256
+        learning_rate: float = 1e-3
+        random_state: int = 42
+
+    config_path = os.path.join(
+        utils.config.read_folders_structure()["config_folder"],
+        "lstm_config.yaml",
+    )
+
+    with open(config_path, "r") as f:
+        raw_config = yaml.safe_load(f)
+
+    try:
+        return ConfigModel(**raw_config)
+    except ValidationError as e:
+        raise ValueError(
+            f"Configuration validation error: {e}"
+        ) from e
+
+
+def load(model_path: str) -> LSTMRegressor:
+    """
+    Load a trained LSTM model from a checkpoint file.
+
+    Parameters
+    ----------
+    model_path : str
+        Path to a ``.pt`` checkpoint created by :func:`save`.
+
+    Returns
+    -------
+    LSTMRegressor
+        Fitted LSTM model ready for inference.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``model_path`` does not exist.
+    """
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(
+            f"Model checkpoint not found: {model_path}"
+        )
+
+    checkpoint = torch.load(model_path, weights_only=False)
+
+    lstm_model = LSTMRegressor(**checkpoint["params"])
+    lstm_model.n_features_in_ = checkpoint["n_features_in_"]
+
+    if "feature_names_in_" in checkpoint:
+        lstm_model.feature_names_in_ = np.array(
+            checkpoint["feature_names_in_"]
+        )
+
+    lstm_model.net_ = _LSTMNet(
+        lstm_model.n_features_in_,
+        lstm_model.n_units,
+        lstm_model.n_layers,
+        lstm_model.dropout,
+    )
+    lstm_model.net_.load_state_dict(checkpoint["state_dict"])
+    lstm_model.net_.eval()
+
+    logging.info(f"Trained model loaded from {model_path}")
+
+    return lstm_model
+
+
+def save(lstm_model: LSTMRegressor, model_name: str) -> None:
+    """
+    Save a trained LSTM model to the trained models folder.
+
+    Parameters
+    ----------
+    lstm_model : LSTMRegressor
+        Fitted LSTM model to serialise.
+    model_name : str
+        File stem for the output file (the ``.pt`` extension is
+        appended automatically).
+    """
+    model_folder = utils.config.read_folders_structure()[
+        "trained_ml_models_folder"
+    ]
+    os.makedirs(model_folder, exist_ok=True)
+
+    output_path = os.path.join(model_folder, f"{model_name}.pt")
+
+    checkpoint: dict = {
+        "params": lstm_model.get_params(),
+        "n_features_in_": int(lstm_model.n_features_in_),
+        "state_dict": lstm_model.net_.state_dict(),
+    }
+    if hasattr(lstm_model, "feature_names_in_"):
+        checkpoint["feature_names_in_"] = (
+            lstm_model.feature_names_in_.tolist()
+        )
+
+    torch.save(checkpoint, output_path)
+
+    logging.info(f"Trained model saved to {output_path}")
+
+
+def get_initialized_model() -> LSTMRegressor:
+    """
+    Return an LSTM model initialised from the YAML configuration.
+
+    Returns
+    -------
+    LSTMRegressor
+        Un-fitted LSTM regressor with config-derived hyperparameters.
+    """
+    config = _read_configuration()
+
+    lstm_model = LSTMRegressor(
+        n_timesteps=config.n_timesteps,
+        n_units=config.n_units,
+        n_layers=config.n_layers,
+        dropout=config.dropout,
+        epochs=config.epochs,
+        batch_size=config.batch_size,
+        learning_rate=config.learning_rate,
+        random_state=config.random_state,
+    )
+
+    logging.info("LSTM model initialised with configuration.")
+
+    return lstm_model
+
+
+def train(
+    prepared_dataset: dict[
+        str, dict[str, pandas.DataFrame | pandas.Series]
+    ],
+) -> LSTMRegressor:
+    """
+    Train an LSTM model on the prepared dataset.
+
+    Only the ``"training"`` split is used to fit the model. Group
+    labels from ``prepared_dataset["training"]["group"]`` are passed
+    to ``fit()`` so that sequences never cross entity boundaries.
+
+    Parameters
+    ----------
+    prepared_dataset :
+        dict[str, dict[str, pandas.DataFrame | pandas.Series]]
+        Dataset produced by ``utils.ml.prepare_dataset`` with at
+        least a ``"training"`` key containing ``"features"``,
+        ``"target"``, and ``"group"`` sub-keys.
+
+    Returns
+    -------
+    LSTMRegressor
+        Fitted LSTM model.
+    """
+    logging.info("Starting LSTM model training.")
+
+    lstm_model = get_initialized_model()
+
+    training = prepared_dataset["training"]
+    lstm_model.fit(
+        training["features"],
+        training["target"],
+        groups=training.get("group"),
+    )
+
+    logging.info("LSTM model training completed.")
+
+    return lstm_model
+
+
+def predict(
+    lstm_model: LSTMRegressor,
+    prepared_dataset: dict[
+        str,
+        pandas.Series
+        | pandas.DataFrame
+        | dict[str, pandas.DataFrame | pandas.Series],
+    ],
+) -> pandas.Series | dict[str, pandas.Series]:
+    """
+    Make predictions with a trained LSTM model.
+
+    Supports two calling modes:
+
+    *Single-dataset mode*: ``prepared_dataset`` contains a
+    ``"features"`` key at the top level (no train/val/test split).
+    Returns a bare ``pandas.Series``.
+
+    *Multi-split mode*: ``prepared_dataset`` contains
+    ``"training"``, ``"validation"``, and/or ``"testing"`` keys,
+    each with their own ``"features"`` and ``"group"`` sub-keys.
+    Returns a ``dict`` mapping split name to ``pandas.Series``.
+
+    Parameters
+    ----------
+    lstm_model : LSTMRegressor
+        Fitted LSTM model.
+    prepared_dataset :
+        dict[str, pandas.Series | pandas.DataFrame |
+        dict[str, pandas.DataFrame | pandas.Series]]
+        Dataset produced by ``utils.ml.prepare_dataset``.
+
+    Returns
+    -------
+    pandas.Series or dict[str, pandas.Series]
+        Predictions in single-dataset or multi-split mode
+        respectively.
+    """
+    logging.info("Making predictions with the trained LSTM model.")
+
+    if "features" in prepared_dataset:
+        preds = lstm_model.predict(
+            prepared_dataset["features"],
+            groups=prepared_dataset.get("group"),
+        )
+        return pandas.Series(preds)
+
+    predictions: dict[str, pandas.Series] = {}
+    for split_name, data in prepared_dataset.items():
+        preds = lstm_model.predict(
+            data["features"],
+            groups=data.get("group"),
+        )
+        predictions[split_name] = pandas.Series(preds)
+        logging.info(
+            f"Predictions made for {split_name} set: "
+            f"{len(preds)} records."
+        )
+    return predictions

--- a/demandcast/ml_models/lstm.py
+++ b/demandcast/ml_models/lstm.py
@@ -18,20 +18,13 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 
 # isort: off
-# Windows: CPython GC calls RemoveDllDirectory when the token from
-# add_dll_directory is collected; storing the token prevents removal.
 # torch must be imported before pandas — pandas side-effects corrupt
 # the Windows DLL loader state for torch's c10.dll initialisation.
-_dll_dir_tokens: list = []
-if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
-    for _sp in sys.path:
-        _torch_lib = os.path.join(_sp, "torch", "lib")
-        if os.path.isdir(_torch_lib):
-            _dll_dir_tokens.append(os.add_dll_directory(_torch_lib))
-            break
+import utils.torch_windows  # noqa: E402
+
+_dll_dir_tokens = utils.torch_windows.enable_torch_dll_directory()
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
 import torch.nn as nn  # noqa: E402
@@ -200,6 +193,9 @@ class LSTMRegressor(BaseEstimator, RegressorMixin):
         X_seq = np.zeros(
             (n_samples, self.n_timesteps, n_features), dtype=X.dtype
         )
+        # Builds one row at a time: fine for the current 3-country
+        # benchmark, but may be worth vectorizing for full-scale
+        # datasets with 40+ countries.
         for i in range(n_samples):
             window_start = max(run_start[i], i - self.n_timesteps + 1)
             n_valid = i - window_start + 1
@@ -385,7 +381,7 @@ def load(model_path: str) -> LSTMRegressor:
     if not os.path.exists(model_path):
         raise FileNotFoundError(f"Model checkpoint not found: {model_path}")
 
-    checkpoint = torch.load(model_path, weights_only=False)
+    checkpoint = torch.load(model_path, weights_only=True)
 
     lstm_model = LSTMRegressor(**checkpoint["params"])
     lstm_model.n_features_in_ = checkpoint["n_features_in_"]

--- a/demandcast/pyproject.toml
+++ b/demandcast/pyproject.toml
@@ -40,9 +40,18 @@ dependencies = [
     "timezonefinder>=6.5.9",
     "tqdm>=4.67.1",
     "xarray>=2025.1.2",
+    "torch>=2.0.0",
     "xgboost-cpu>=3.1.2",
     "xlrd>=2.0.1",
 ]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cpu" }
 
 [dependency-groups]
 dev = [

--- a/demandcast/pyproject.toml
+++ b/demandcast/pyproject.toml
@@ -40,9 +40,13 @@ dependencies = [
     "timezonefinder>=6.5.9",
     "tqdm>=4.67.1",
     "xarray>=2025.1.2",
-    "torch>=2.0.0",
     "xgboost-cpu>=3.1.2",
     "xlrd>=2.0.1",
+]
+
+[project.optional-dependencies]
+lstm = [
+    "torch>=2.0.0",
 ]
 
 [[tool.uv.index]]

--- a/demandcast/tests/conftest.py
+++ b/demandcast/tests/conftest.py
@@ -14,7 +14,7 @@ Description:
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import os
 import sys
 

--- a/demandcast/tests/conftest.py
+++ b/demandcast/tests/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    Shared pytest configuration for the demandcast test suite.
+
+    On Windows with Python 3.12, importing pandas before torch corrupts
+    the Windows DLL loader state needed by torch's c10.dll. This file
+    is auto-loaded by pytest before any test module, ensuring torch is
+    initialised first when it is available.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+if sys.platform == "win32" and importlib.util.find_spec("torch") is not None:
+    _dll_dir_tokens: list = []
+    if hasattr(os, "add_dll_directory"):
+        for _sp in sys.path:
+            _torch_lib = os.path.join(_sp, "torch", "lib")
+            if os.path.isdir(_torch_lib):
+                _dll_dir_tokens.append(os.add_dll_directory(_torch_lib))
+                break
+    import torch  # noqa: F401

--- a/demandcast/tests/conftest.py
+++ b/demandcast/tests/conftest.py
@@ -15,15 +15,10 @@ Description:
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 
+import utils.torch_windows
+
 if sys.platform == "win32" and importlib.util.find_spec("torch") is not None:
-    _dll_dir_tokens: list = []
-    if hasattr(os, "add_dll_directory"):
-        for _sp in sys.path:
-            _torch_lib = os.path.join(_sp, "torch", "lib")
-            if os.path.isdir(_torch_lib):
-                _dll_dir_tokens.append(os.add_dll_directory(_torch_lib))
-                break
+    _dll_dir_tokens = utils.torch_windows.enable_torch_dll_directory()
     import torch  # noqa: F401

--- a/demandcast/tests/test_cross_validate.py
+++ b/demandcast/tests/test_cross_validate.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    Unit tests for cross_validate.py, focused on the manual
+    Leave-One-Group-Out cross-validation path used for the LSTM
+    algorithm (``_cross_validate_lstm``). Unlike sklearn's
+    ``cross_validate()``, this path must forward ``groups`` into
+    both training and prediction so that sequences never cross
+    entity boundaries.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("torch", reason="torch not installed; skipping LSTM tests")
+
+import cross_validate  # noqa: E402
+import ml_models.lstm as lstm_module  # noqa: E402
+
+# Small hyperparameters so every test trains in under a second on CPU.
+_FAST_CONFIG = MagicMock(
+    n_timesteps=4,
+    n_units=8,
+    n_layers=1,
+    dropout=0.0,
+    epochs=1,
+    batch_size=32,
+    learning_rate=1e-3,
+    random_state=42,
+)
+
+_ENTITIES = ["DEU", "FRA", "GBR"]
+
+
+def _make_prepared_dataset() -> dict:
+    """
+    Build a flat prepared_dataset spanning three entities.
+
+    Returns
+    -------
+    dict
+        Dict with "features", "target", and "group" keys, matching
+        the output of ``utils.ml.prepare_dataset(testing_set=False,
+        validation_set=False)``.
+    """
+    rng = np.random.default_rng(0)
+    n_per = 20
+    total = len(_ENTITIES) * n_per
+    features = pd.DataFrame(
+        rng.standard_normal((total, 3)), columns=["a", "b", "c"]
+    )
+    target = pd.Series(rng.uniform(1e-4, 3e-4, total), name="target")
+    group = pd.Series(np.repeat(_ENTITIES, n_per), name="Entity code")
+    return {"features": features, "target": target, "group": group}
+
+
+def test_cross_validate_lstm_returns_one_row_per_entity():
+    """One MAPE row is produced per held-out entity."""
+    dataset = _make_prepared_dataset()
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        mapes = cross_validate._cross_validate_lstm(
+            dataset, "neg_mean_absolute_percentage_error"
+        )
+
+    assert sorted(mapes["Entity Code"].tolist()) == sorted(_ENTITIES)
+    assert mapes["Training MAPE"].notna().all()
+    assert mapes["Testing MAPE"].notna().all()
+
+
+def test_cross_validate_lstm_forwards_groups_to_train():
+    """
+    Training folds carry group labels that exclude the held-out entity.
+
+    Regression test for the bug where sklearn's cross_validate()
+    never forwarded ``groups`` into ``estimator.fit()``, so the LSTM
+    silently received ``groups=None`` and built sequences across
+    country boundaries during cross-validation.
+    """
+    dataset = _make_prepared_dataset()
+    seen_calls: list[pd.Series] = []
+    real_train = lstm_module.train
+
+    def spy_train(prepared_dataset):
+        seen_calls.append(prepared_dataset["training"]["group"])
+        return real_train(prepared_dataset)
+
+    with (
+        patch("ml_models.lstm._read_configuration", return_value=_FAST_CONFIG),
+        patch("ml_models.lstm.train", side_effect=spy_train),
+    ):
+        cross_validate._cross_validate_lstm(
+            dataset, "neg_mean_absolute_percentage_error"
+        )
+
+    assert len(seen_calls) == len(_ENTITIES)
+    for group_arg in seen_calls:
+        assert group_arg is not None
+        missing_entities = set(_ENTITIES) - set(group_arg.unique())
+        assert missing_entities, (
+            "Training fold groups included every entity; the held-out "
+            "entity was not excluded from the group labels passed to "
+            "train()."
+        )
+        assert len(missing_entities) == 1

--- a/demandcast/tests/test_lstm.py
+++ b/demandcast/tests/test_lstm.py
@@ -33,10 +33,9 @@ torch = pytest.importorskip(
 
 import ml_models.lstm as lstm_module  # noqa: E402
 
-
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 # Small hyperparameters so every test trains in under a second on CPU.
 _FAST_CONFIG = MagicMock(
@@ -59,7 +58,15 @@ def _make_split(
     entities: list[str],
     n_per: int,
 ) -> dict:
-    """Build one split whose structure matches _split_in_groups output."""
+    """
+    Build one split whose structure matches _split_in_groups output.
+
+    Returns
+    -------
+    dict
+        Dict with "features", "target", "group", "time", and
+        "scaling_factor" keys.
+    """
     total = len(entities) * n_per
     features = pd.DataFrame(
         rng.standard_normal((total, len(_FEATURE_NAMES))),
@@ -68,9 +75,7 @@ def _make_split(
     target = pd.Series(
         rng.uniform(1e-4, 3e-4, total), name="Load (fraction of annual total)"
     )
-    group = pd.Series(
-        np.repeat(entities, n_per), name="Entity code"
-    )
+    group = pd.Series(np.repeat(entities, n_per), name="Entity code")
     time = pd.Series(
         pd.date_range("2020-01-01", periods=total, freq="h"),
         name="Time (UTC)",
@@ -86,7 +91,15 @@ def _make_split(
 
 
 def _make_prepared_dataset() -> dict:
-    """Return a multi-split prepared_dataset with 3 entities."""
+    """
+    Return a multi-split prepared_dataset with 3 entities.
+
+    Returns
+    -------
+    dict
+        Dict with "training", "validation", and "testing" keys, each
+        a split dict as returned by _make_split.
+    """
     rng = np.random.default_rng(0)
     return {
         "training": _make_split(rng, _ENTITIES, 60),
@@ -95,9 +108,9 @@ def _make_prepared_dataset() -> dict:
     }
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # _read_configuration
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_read_configuration_returns_correct_values():
@@ -168,9 +181,9 @@ def test_read_configuration_raises_on_bad_type():
             lstm_module._read_configuration()
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # get_initialized_model
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_get_initialized_model_returns_lstm_regressor():
@@ -197,9 +210,9 @@ def test_get_initialized_model_uses_config_values():
     assert model.random_state == _FAST_CONFIG.random_state
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # train
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_train_returns_lstm_regressor():
@@ -240,14 +253,21 @@ def test_train_only_uses_training_split():
     assert isinstance(model, lstm_module.LSTMRegressor)
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # predict — multi-split mode
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
 def trained_model_and_dataset():
-    """Return a (model, dataset) pair shared across predict tests."""
+    """
+    Return a (model, dataset) pair shared across predict tests.
+
+    Returns
+    -------
+    tuple[LSTMRegressor, dict]
+        Fitted LSTM model and the prepared_dataset used to train it.
+    """
     dataset = _make_prepared_dataset()
     with patch(
         "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
@@ -277,7 +297,7 @@ def test_predict_multi_split_all_series(trained_model_and_dataset):
 
 
 def test_predict_multi_split_correct_lengths(trained_model_and_dataset):
-    """Prediction length matches the number of feature rows per split."""
+    """Prediction length matches feature row count per split."""
     model, dataset = trained_model_and_dataset
     result = lstm_module.predict(model, dataset)
 
@@ -289,9 +309,9 @@ def test_predict_multi_split_correct_lengths(trained_model_and_dataset):
         )
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # predict — single-dataset mode
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_predict_single_dataset_returns_series(trained_model_and_dataset):
@@ -314,9 +334,9 @@ def test_predict_single_dataset_correct_length(trained_model_and_dataset):
     assert len(result) == len(single["features"])
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # save / load round-trip
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_save_creates_pt_file(trained_model_and_dataset):
@@ -379,9 +399,9 @@ def test_load_raises_if_file_missing():
         lstm_module.load("/nonexistent/path/model.pt")
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # feature_names_in_ compatibility (validate.py / forecast.py checks)
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_feature_names_in_tolist_returns_python_list(
@@ -390,9 +410,10 @@ def test_feature_names_in_tolist_returns_python_list(
     """
     feature_names_in_.tolist() returns a plain Python list of strings.
 
-    validate.py and forecast.py call ``model.feature_names_in_.tolist()``
-    and compare it to ``df.columns.tolist()``. Both sides must be plain
-    Python lists of strings for the equality check to work.
+    validate.py and forecast.py call
+    ``model.feature_names_in_.tolist()`` and compare it to
+    ``df.columns.tolist()``. Both sides must be plain Python lists
+    of strings for the equality check to work.
     """
     model, _ = trained_model_and_dataset
     result = model.feature_names_in_.tolist()
@@ -408,9 +429,10 @@ def test_feature_names_check_passes_against_matching_dataset(
     The validate.py / forecast.py feature-name guard passes for LSTM.
 
     Simulates the exact check both scripts perform: compare
-    ``df.columns.tolist()`` against ``model.feature_names_in_.tolist()``.
-    A failure here means the dispatch branches would incorrectly raise
-    ValueError even when the data matches the training features.
+    ``df.columns.tolist()`` against
+    ``model.feature_names_in_.tolist()``. A failure here means the
+    dispatch branches would incorrectly raise ValueError even when
+    the data matches the training features.
     """
     model, dataset = trained_model_and_dataset
     # validate.py uses the training split; forecast.py uses the bare
@@ -427,9 +449,9 @@ def test_feature_names_check_passes_against_matching_dataset(
     )
 
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Entity-boundary integrity
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 
 def test_predict_respects_entity_boundaries():

--- a/demandcast/tests/test_lstm.py
+++ b/demandcast/tests/test_lstm.py
@@ -1,0 +1,475 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    Unit tests for ml_models.lstm.
+
+    Tests use a small synthetic dataset whose structure exactly mirrors
+    the output of ``utils.ml.prepare_dataset(testing_set=True,
+    validation_set=True)``: a dict with ``"training"``,
+    ``"validation"``, and ``"testing"`` keys, each containing
+    ``"features"``, ``"target"``, ``"group"``, ``"time"``, and
+    ``"scaling_factor"`` sub-keys.
+
+    Where file I/O or configuration reading is needed, the tests patch
+    the relevant functions rather than touching the real file system.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, mock_open, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip(
+    "torch", reason="torch not installed; skipping LSTM tests"
+)
+
+import ml_models.lstm as lstm_module  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Small hyperparameters so every test trains in under a second on CPU.
+_FAST_CONFIG = MagicMock(
+    n_timesteps=4,
+    n_units=8,
+    n_layers=1,
+    dropout=0.0,
+    epochs=2,
+    batch_size=32,
+    learning_rate=1e-3,
+    random_state=42,
+)
+
+_FEATURE_NAMES = ["hour", "month", "weekend", "temperature", "gdp_ppp"]
+_ENTITIES = ["DEU", "FRA", "GBR"]
+
+
+def _make_split(
+    rng: np.random.Generator,
+    entities: list[str],
+    n_per: int,
+) -> dict:
+    """Build one split whose structure matches _split_in_groups output."""
+    total = len(entities) * n_per
+    features = pd.DataFrame(
+        rng.standard_normal((total, len(_FEATURE_NAMES))),
+        columns=_FEATURE_NAMES,
+    )
+    target = pd.Series(
+        rng.uniform(1e-4, 3e-4, total), name="Load (fraction of annual total)"
+    )
+    group = pd.Series(
+        np.repeat(entities, n_per), name="Entity code"
+    )
+    time = pd.Series(
+        pd.date_range("2020-01-01", periods=total, freq="h"),
+        name="Time (UTC)",
+    )
+    scaling_factor = pd.Series(np.ones(total) * 1e9)
+    return {
+        "features": features,
+        "target": target,
+        "group": group,
+        "time": time,
+        "scaling_factor": scaling_factor,
+    }
+
+
+def _make_prepared_dataset() -> dict:
+    """Return a multi-split prepared_dataset with 3 entities."""
+    rng = np.random.default_rng(0)
+    return {
+        "training": _make_split(rng, _ENTITIES, 60),
+        "validation": _make_split(rng, _ENTITIES, 12),
+        "testing": _make_split(rng, _ENTITIES, 12),
+    }
+
+
+# ---------------------------------------------------------------------------
+# _read_configuration
+# ---------------------------------------------------------------------------
+
+
+def test_read_configuration_returns_correct_values():
+    """Values read from YAML are reflected in the config model."""
+    yaml_content = (
+        "n_timesteps: 48\n"
+        "n_units: 64\n"
+        "n_layers: 2\n"
+        "dropout: 0.1\n"
+        "epochs: 20\n"
+        "batch_size: 128\n"
+        "learning_rate: 0.0005\n"
+        "random_state: 7\n"
+    )
+    with (
+        patch(
+            "utils.config.read_folders_structure",
+            return_value={"config_folder": "/cfg"},
+        ),
+        patch("builtins.open", mock_open(read_data=yaml_content)),
+    ):
+        config = lstm_module._read_configuration()
+
+    assert config.n_timesteps == 48
+    assert config.n_units == 64
+    assert config.n_layers == 2
+    assert config.dropout == 0.1
+    assert config.epochs == 20
+    assert config.batch_size == 128
+    assert config.learning_rate == 0.0005
+    assert config.random_state == 7
+
+
+def test_read_configuration_defaults_on_empty_yaml():
+    """An empty YAML file returns default hyperparameters."""
+    with (
+        patch(
+            "utils.config.read_folders_structure",
+            return_value={"config_folder": "/cfg"},
+        ),
+        patch("builtins.open", mock_open(read_data="{}\n")),
+    ):
+        config = lstm_module._read_configuration()
+
+    assert config.n_timesteps == 24
+    assert config.n_units == 32
+    assert config.n_layers == 1
+    assert config.dropout == 0.0
+    assert config.epochs == 5
+    assert config.batch_size == 256
+    assert config.learning_rate == 1e-3
+    assert config.random_state == 42
+
+
+def test_read_configuration_raises_on_bad_type():
+    """A wrong value type raises ValueError."""
+    with (
+        patch(
+            "utils.config.read_folders_structure",
+            return_value={"config_folder": "/cfg"},
+        ),
+        patch(
+            "builtins.open",
+            mock_open(read_data="n_timesteps: not_an_int\n"),
+        ),
+    ):
+        with pytest.raises(ValueError, match="Configuration validation"):
+            lstm_module._read_configuration()
+
+
+# ---------------------------------------------------------------------------
+# get_initialized_model
+# ---------------------------------------------------------------------------
+
+
+def test_get_initialized_model_returns_lstm_regressor():
+    """get_initialized_model returns a fresh, unfitted LSTMRegressor."""
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.get_initialized_model()
+
+    assert isinstance(model, lstm_module.LSTMRegressor)
+    assert not hasattr(model, "net_"), "Model should not be fitted yet"
+
+
+def test_get_initialized_model_uses_config_values():
+    """Hyperparameters from config are forwarded to LSTMRegressor."""
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.get_initialized_model()
+
+    assert model.n_timesteps == _FAST_CONFIG.n_timesteps
+    assert model.n_units == _FAST_CONFIG.n_units
+    assert model.epochs == _FAST_CONFIG.epochs
+    assert model.random_state == _FAST_CONFIG.random_state
+
+
+# ---------------------------------------------------------------------------
+# train
+# ---------------------------------------------------------------------------
+
+
+def test_train_returns_lstm_regressor():
+    """train() returns a fitted LSTMRegressor instance."""
+    dataset = _make_prepared_dataset()
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.train(dataset)
+
+    assert isinstance(model, lstm_module.LSTMRegressor)
+    assert hasattr(model, "net_"), "Model must be fitted after train()"
+
+
+def test_train_sets_feature_names():
+    """After train(), feature_names_in_ matches the dataset columns."""
+    dataset = _make_prepared_dataset()
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.train(dataset)
+
+    assert model.feature_names_in_.tolist() == _FEATURE_NAMES
+
+
+def test_train_only_uses_training_split():
+    """train() only reads the 'training' key; extra keys are ignored."""
+    dataset = _make_prepared_dataset()
+    # Remove validation and testing — train must not fail.
+    del dataset["validation"]
+    del dataset["testing"]
+
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.train(dataset)
+
+    assert isinstance(model, lstm_module.LSTMRegressor)
+
+
+# ---------------------------------------------------------------------------
+# predict — multi-split mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def trained_model_and_dataset():
+    """Return a (model, dataset) pair shared across predict tests."""
+    dataset = _make_prepared_dataset()
+    with patch(
+        "ml_models.lstm._read_configuration", return_value=_FAST_CONFIG
+    ):
+        model = lstm_module.train(dataset)
+    return model, dataset
+
+
+def test_predict_multi_split_returns_dict(trained_model_and_dataset):
+    """Multi-split predict() returns a dict keyed by split name."""
+    model, dataset = trained_model_and_dataset
+    result = lstm_module.predict(model, dataset)
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"training", "validation", "testing"}
+
+
+def test_predict_multi_split_all_series(trained_model_and_dataset):
+    """Each value in the multi-split result is a pandas.Series."""
+    model, dataset = trained_model_and_dataset
+    result = lstm_module.predict(model, dataset)
+
+    for split, series in result.items():
+        assert isinstance(series, pd.Series), (
+            f"Expected Series for split '{split}', got {type(series)}"
+        )
+
+
+def test_predict_multi_split_correct_lengths(trained_model_and_dataset):
+    """Prediction length matches the number of feature rows per split."""
+    model, dataset = trained_model_and_dataset
+    result = lstm_module.predict(model, dataset)
+
+    for split in ("training", "validation", "testing"):
+        expected = len(dataset[split]["features"])
+        actual = len(result[split])
+        assert actual == expected, (
+            f"Split '{split}': expected {expected} rows, got {actual}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# predict — single-dataset mode
+# ---------------------------------------------------------------------------
+
+
+def test_predict_single_dataset_returns_series(trained_model_and_dataset):
+    """Single-dataset predict() returns a bare pandas.Series."""
+    model, dataset = trained_model_and_dataset
+    single = dataset["training"]  # has "features" key at top level
+
+    result = lstm_module.predict(model, single)
+
+    assert isinstance(result, pd.Series)
+
+
+def test_predict_single_dataset_correct_length(trained_model_and_dataset):
+    """Single-dataset prediction length equals the number of rows."""
+    model, dataset = trained_model_and_dataset
+    single = dataset["testing"]
+
+    result = lstm_module.predict(model, single)
+
+    assert len(result) == len(single["features"])
+
+
+# ---------------------------------------------------------------------------
+# save / load round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_creates_pt_file(trained_model_and_dataset):
+    """save() writes a .pt file to the trained models folder."""
+    model, _ = trained_model_and_dataset
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "ml_models.lstm.utils.config.read_folders_structure",
+            return_value={"trained_ml_models_folder": tmpdir},
+        ):
+            lstm_module.save(model, "lstm_model_test")
+
+        assert os.path.isfile(os.path.join(tmpdir, "lstm_model_test.pt"))
+
+
+def test_load_restores_feature_names(trained_model_and_dataset):
+    """load() restores feature_names_in_ from the checkpoint."""
+    model, _ = trained_model_and_dataset
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pt_path = os.path.join(tmpdir, "test_model.pt")
+        with patch(
+            "ml_models.lstm.utils.config.read_folders_structure",
+            return_value={"trained_ml_models_folder": tmpdir},
+        ):
+            lstm_module.save(model, "test_model")
+
+        loaded = lstm_module.load(pt_path)
+
+    assert loaded.feature_names_in_.tolist() == _FEATURE_NAMES
+
+
+def test_load_predictions_match_original(trained_model_and_dataset):
+    """Predictions from a loaded model match the original model."""
+    model, dataset = trained_model_and_dataset
+    features = dataset["testing"]["features"]
+    groups = dataset["testing"]["group"]
+
+    preds_original = model.predict(features, groups=groups)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pt_path = os.path.join(tmpdir, "test_model.pt")
+        with patch(
+            "ml_models.lstm.utils.config.read_folders_structure",
+            return_value={"trained_ml_models_folder": tmpdir},
+        ):
+            lstm_module.save(model, "test_model")
+
+        loaded = lstm_module.load(pt_path)
+
+    preds_loaded = loaded.predict(features, groups=groups)
+
+    np.testing.assert_allclose(preds_original, preds_loaded, rtol=1e-5)
+
+
+def test_load_raises_if_file_missing():
+    """load() raises FileNotFoundError for a nonexistent path."""
+    with pytest.raises(FileNotFoundError):
+        lstm_module.load("/nonexistent/path/model.pt")
+
+
+# ---------------------------------------------------------------------------
+# feature_names_in_ compatibility (validate.py / forecast.py checks)
+# ---------------------------------------------------------------------------
+
+
+def test_feature_names_in_tolist_returns_python_list(
+    trained_model_and_dataset,
+):
+    """
+    feature_names_in_.tolist() returns a plain Python list of strings.
+
+    validate.py and forecast.py call ``model.feature_names_in_.tolist()``
+    and compare it to ``df.columns.tolist()``. Both sides must be plain
+    Python lists of strings for the equality check to work.
+    """
+    model, _ = trained_model_and_dataset
+    result = model.feature_names_in_.tolist()
+    assert isinstance(result, list)
+    assert all(isinstance(s, str) for s in result)
+    assert result == _FEATURE_NAMES
+
+
+def test_feature_names_check_passes_against_matching_dataset(
+    trained_model_and_dataset,
+):
+    """
+    The validate.py / forecast.py feature-name guard passes for LSTM.
+
+    Simulates the exact check both scripts perform: compare
+    ``df.columns.tolist()`` against ``model.feature_names_in_.tolist()``.
+    A failure here means the dispatch branches would incorrectly raise
+    ValueError even when the data matches the training features.
+    """
+    model, dataset = trained_model_and_dataset
+    # validate.py uses the training split; forecast.py uses the bare
+    # "features" key — test both access patterns.
+    training_features = dataset["training"]["features"].columns.tolist()
+    bare_features = dataset["training"]["features"].columns.tolist()
+    model_features = model.feature_names_in_.tolist()
+
+    assert training_features == model_features, (
+        "validate.py-style check would raise ValueError"
+    )
+    assert bare_features == model_features, (
+        "forecast.py-style check would raise ValueError"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entity-boundary integrity
+# ---------------------------------------------------------------------------
+
+
+def test_predict_respects_entity_boundaries():
+    """
+    Sequences must not borrow rows across entity boundaries.
+
+    Uses entity-specific feature values (ord of entity letter) to
+    detect cross-entity contamination: any non-zero timestep value
+    that doesn't belong to the current entity's ordinal is a violation.
+    """
+    rng = np.random.default_rng(7)
+    n_per = 50
+    n_timesteps = 6
+    n_features = 3
+    entities = ["A", "B", "C"]
+
+    X_parts, g_parts = [], []
+    for e in entities:
+        base = float(ord(e))
+        noise = rng.standard_normal((n_per, n_features)) * 1e-3
+        X_parts.append(np.full((n_per, n_features), base) + noise)
+        g_parts.extend([e] * n_per)
+
+    X_arr = np.vstack(X_parts).astype(np.float32)
+    groups = np.array(g_parts)
+
+    probe = lstm_module.LSTMRegressor(
+        n_timesteps=n_timesteps, n_units=4, epochs=1, batch_size=16
+    )
+    X_seq = probe._make_sequences(X_arr, groups=groups)
+
+    violations = 0
+    for i in range(len(X_arr)):
+        expected_val = float(ord(groups[i]))
+        for t in range(n_timesteps):
+            v = X_seq[i, t, 0]
+            if abs(v) > 0.5 and abs(v - expected_val) > 0.5:
+                violations += 1
+                break
+
+    assert violations == 0, (
+        f"{violations} sequences contain rows from the wrong entity"
+    )

--- a/demandcast/tests/test_ml.py
+++ b/demandcast/tests/test_ml.py
@@ -189,9 +189,7 @@ def test_get_trained_model_path_pt_extension():
             "xgboost_model_20240103_120000.json",
         ]
 
-        result = utils.ml.get_trained_model_path(
-            None, "lstm", extension=".pt"
-        )
+        result = utils.ml.get_trained_model_path(None, "lstm", extension=".pt")
 
         assert result == os.path.join(
             "/models", "lstm_model_20240102_120000.pt"

--- a/demandcast/tests/test_ml.py
+++ b/demandcast/tests/test_ml.py
@@ -7,6 +7,7 @@ Description:
     This file contains unit tests for the ml module.
 """
 
+import os
 from unittest.mock import Mock, mock_open, patch
 
 import pandas
@@ -166,6 +167,61 @@ def test_get_trained_model_path_no_files_found():
 
         with pytest.raises(FileNotFoundError):
             utils.ml.get_trained_model_path(None, "xgboost")
+
+
+def test_get_trained_model_path_pt_extension():
+    """
+    Test get_trained_model_path with ``.pt`` extension for LSTM.
+
+    Verifies the extension parameter selects ``.pt`` files and picks
+    the latest by datetime stamp.
+    """
+    with (
+        patch("utils.config.read_folders_structure") as mock_read_folders,
+        patch("os.listdir") as mock_listdir,
+    ):
+        mock_read_folders.return_value = {
+            "trained_ml_models_folder": "/models"
+        }
+        mock_listdir.return_value = [
+            "lstm_model_20240101_120000.pt",
+            "lstm_model_20240102_120000.pt",
+            "xgboost_model_20240103_120000.json",
+        ]
+
+        result = utils.ml.get_trained_model_path(
+            None, "lstm", extension=".pt"
+        )
+
+        assert result == os.path.join(
+            "/models", "lstm_model_20240102_120000.pt"
+        )
+
+
+def test_get_trained_model_path_xgboost_unchanged_with_pt_present():
+    """
+    XGBoost path search ignores ``.pt`` files even when they exist.
+
+    Ensures the extension parameter keeps the two algorithm namespaces
+    fully separated.
+    """
+    with (
+        patch("utils.config.read_folders_structure") as mock_read_folders,
+        patch("os.listdir") as mock_listdir,
+    ):
+        mock_read_folders.return_value = {
+            "trained_ml_models_folder": "/models"
+        }
+        mock_listdir.return_value = [
+            "xgboost_model_20240101_120000.json",
+            "lstm_model_20240103_120000.pt",
+        ]
+
+        result = utils.ml.get_trained_model_path(None, "xgboost")
+
+        assert result == os.path.join(
+            "/models", "xgboost_model_20240101_120000.json"
+        )
 
 
 def test_get_assemble_data_path_with_provided_path():

--- a/demandcast/tests/test_torch_windows.py
+++ b/demandcast/tests/test_torch_windows.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    Unit tests for utils.torch_windows.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import utils.torch_windows as torch_windows_module
+
+
+def test_returns_empty_list_on_non_windows():
+    """No tokens are added when the platform is not win32."""
+    with patch.object(torch_windows_module.sys, "platform", "linux"):
+        tokens = torch_windows_module.enable_torch_dll_directory()
+
+    assert tokens == []
+
+
+def test_returns_empty_list_without_add_dll_directory(monkeypatch):
+    """No tokens are added when os.add_dll_directory is unavailable."""
+    monkeypatch.setattr(torch_windows_module.sys, "platform", "win32")
+    monkeypatch.delattr(
+        torch_windows_module.os, "add_dll_directory", raising=False
+    )
+
+    tokens = torch_windows_module.enable_torch_dll_directory()
+
+    assert tokens == []
+
+
+def test_adds_token_for_matching_torch_lib_directory():
+    """A token is returned for the first matching torch/lib dir."""
+    fake_token = object()
+    match_path = os.path.join("/site-packages", "torch", "lib")
+    with (
+        patch.object(torch_windows_module.sys, "platform", "win32"),
+        patch.object(
+            torch_windows_module.sys, "path", ["/site-packages", "/other"]
+        ),
+        patch.object(
+            torch_windows_module.os,
+            "add_dll_directory",
+            create=True,
+            return_value=fake_token,
+        ) as mock_add_dll_directory,
+        patch.object(
+            torch_windows_module.os.path,
+            "isdir",
+            side_effect=lambda p: p == match_path,
+        ),
+    ):
+        tokens = torch_windows_module.enable_torch_dll_directory()
+
+    assert tokens == [fake_token]
+    mock_add_dll_directory.assert_called_once_with(match_path)
+
+
+def test_stops_after_first_matching_directory():
+    """Only the first matching torch/lib directory is registered."""
+    first_match_path = os.path.join("/first", "torch", "lib")
+    with (
+        patch.object(torch_windows_module.sys, "platform", "win32"),
+        patch.object(
+            torch_windows_module.sys,
+            "path",
+            ["/first", "/second"],
+        ),
+        patch.object(
+            torch_windows_module.os,
+            "add_dll_directory",
+            create=True,
+            return_value=object(),
+        ) as mock_add_dll_directory,
+        patch.object(torch_windows_module.os.path, "isdir", return_value=True),
+    ):
+        torch_windows_module.enable_torch_dll_directory()
+
+    mock_add_dll_directory.assert_called_once_with(first_match_path)
+
+
+def test_returns_empty_list_when_no_directory_matches():
+    """No tokens are returned when no sys.path entry has torch/lib."""
+    with (
+        patch.object(torch_windows_module.sys, "platform", "win32"),
+        patch.object(torch_windows_module.sys, "path", ["/site-packages"]),
+        patch.object(
+            torch_windows_module.os,
+            "add_dll_directory",
+            create=True,
+            return_value=object(),
+        ) as mock_add_dll_directory,
+        patch.object(
+            torch_windows_module.os.path, "isdir", return_value=False
+        ),
+    ):
+        tokens = torch_windows_module.enable_torch_dll_directory()
+
+    assert tokens == []
+    mock_add_dll_directory.assert_not_called()

--- a/demandcast/train.py
+++ b/demandcast/train.py
@@ -12,6 +12,7 @@ Description:
 import logging
 from typing import Optional
 
+import ml_models.lstm
 import ml_models.xgboost
 import pandas
 import utils.config
@@ -110,6 +111,12 @@ def run_model_training(
 
         # Save the trained model.
         ml_models.xgboost.save(model, model_name)
+    elif algorithm.lower() == "lstm":
+        # Train the model.
+        model = ml_models.lstm.train(prepared_dataset)
+
+        # Save the trained model.
+        ml_models.lstm.save(model, model_name)
     else:
         raise ValueError(f"Unsupported algorithm: {algorithm}")
 

--- a/demandcast/utils/config.py
+++ b/demandcast/utils/config.py
@@ -43,7 +43,9 @@ def read_folders_structure() -> dict[str, str]:
     )
 
     # Read the folders structure from the file.
-    with open(folders_structure_file_path, "r") as file:
+    with open(
+        folders_structure_file_path, "r", encoding="utf-8"
+    ) as file:
         folders_structure = yaml.safe_load(file)
 
     # Add the root folder to the folders structure.
@@ -112,7 +114,7 @@ def read_configuration(
         )
 
     # Read the configuration file.
-    with open(config_file_path, "r") as file:
+    with open(config_file_path, "r", encoding="utf-8") as file:
         config = yaml.safe_load(file)
 
     return config

--- a/demandcast/utils/config.py
+++ b/demandcast/utils/config.py
@@ -43,9 +43,7 @@ def read_folders_structure() -> dict[str, str]:
     )
 
     # Read the folders structure from the file.
-    with open(
-        folders_structure_file_path, "r", encoding="utf-8"
-    ) as file:
+    with open(folders_structure_file_path, "r", encoding="utf-8") as file:
         folders_structure = yaml.safe_load(file)
 
     # Add the root folder to the folders structure.

--- a/demandcast/utils/entities.py
+++ b/demandcast/utils/entities.py
@@ -234,7 +234,7 @@ def _read_entities_info(
         )
 
     # Read the content from the file.
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         content = yaml.safe_load(file)
 
     # Return the information of the countries and subdivisions.

--- a/demandcast/utils/ml.py
+++ b/demandcast/utils/ml.py
@@ -67,7 +67,11 @@ def read_and_check_ml_configuration() -> BaseModel:
         raise ValueError(f"Configuration validation error: {e}") from e
 
 
-def get_trained_model_path(model_path: str | None, algorithm_name: str) -> str:
+def get_trained_model_path(
+    model_path: str | None,
+    algorithm_name: str,
+    extension: str = ".json",
+) -> str:
     """
     Get the path to the trained model file.
 
@@ -78,6 +82,9 @@ def get_trained_model_path(model_path: str | None, algorithm_name: str) -> str:
         in the default directory will be used.
     algorithm_name : str
         The name of the machine learning algorithm.
+    extension : str, optional
+        File extension of the saved model, e.g. ``".json"`` for
+        XGBoost or ``".pt"`` for LSTM. Defaults to ``".json"``.
 
     Returns
     -------
@@ -106,11 +113,11 @@ def get_trained_model_path(model_path: str | None, algorithm_name: str) -> str:
         for path in model_paths:
             # Extract datetime from the file name.
             datetime_of_file = path[
-                -len(datetime) - len(".json") : -len(".json")
+                -len(datetime) - len(extension) : -len(extension)
             ]
             if (
                 path.startswith(f"{algorithm_name}_model")
-                and path.endswith(".json")
+                and path.endswith(extension)
                 and datetime_of_file > datetime
             ):
                 datetime = datetime_of_file

--- a/demandcast/utils/ml.py
+++ b/demandcast/utils/ml.py
@@ -51,7 +51,7 @@ def read_and_check_ml_configuration() -> BaseModel:
     )
 
     # Read the configuration.
-    with open(config_path, "r") as file:
+    with open(config_path, "r", encoding="utf-8") as file:
         raw_config = utils.config.yaml.safe_load(file)
 
     try:

--- a/demandcast/utils/torch_windows.py
+++ b/demandcast/utils/torch_windows.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+License: AGPL-3.0.
+
+Description:
+
+    This module provides a Windows-specific workaround needed before
+    importing torch. On Windows, importing pandas before torch
+    corrupts the DLL loader state required by torch's c10.dll, so
+    callers must invoke ``enable_torch_dll_directory()`` before
+    importing pandas or torch.
+"""
+
+import os
+import sys
+
+
+def enable_torch_dll_directory() -> list:
+    """
+    Register torch's ``lib`` directory with the Windows DLL loader.
+
+    CPython's garbage collector calls ``RemoveDllDirectory`` when the
+    token returned by ``os.add_dll_directory`` is collected, so
+    callers must keep the returned tokens alive for as long as torch
+    may need to load its DLLs (typically the lifetime of the
+    process), e.g. by assigning the result to a module-level name.
+
+    Returns
+    -------
+    list
+        Tokens returned by ``os.add_dll_directory``, one per matching
+        ``torch/lib`` directory found on ``sys.path``. Empty on
+        non-Windows platforms or when no such directory is found.
+    """
+    tokens: list = []
+    if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+        for path_entry in sys.path:
+            torch_lib = os.path.join(path_entry, "torch", "lib")
+            if os.path.isdir(torch_lib):
+                tokens.append(os.add_dll_directory(torch_lib))
+                break
+    return tokens

--- a/demandcast/utils/uploader.py
+++ b/demandcast/utils/uploader.py
@@ -182,7 +182,7 @@ def upload_to_zenodo(
         )
 
     # Load the metadata from the YAML file.
-    with open(author_metadata_path, "r") as file:
+    with open(author_metadata_path, "r", encoding="utf-8") as file:
         author_metadata = yaml.safe_load(file)
 
     # Extract creators and contributors from the metadata.

--- a/demandcast/uv.lock
+++ b/demandcast/uv.lock
@@ -4,8 +4,10 @@ requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version < '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "(python_full_version >= '3.13' and platform_machine != 'ARM64') or (python_full_version >= '3.13' and sys_platform != 'win32')",
-    "(python_full_version < '3.13' and platform_machine != 'ARM64') or (python_full_version < '3.13' and sys_platform != 'win32')",
+    "(python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "(python_full_version < '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 
 [[package]]
@@ -635,6 +637,8 @@ dependencies = [
     { name = "shapely" },
     { name = "tailwind-colors" },
     { name = "timezonefinder" },
+    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "xarray" },
     { name = "xgboost-cpu" },
@@ -682,6 +686,7 @@ requires-dist = [
     { name = "shapely", specifier = ">=2.0.7" },
     { name = "tailwind-colors", specifier = ">=1.3.0" },
     { name = "timezonefinder", specifier = ">=6.5.9" },
+    { name = "torch", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "xarray", specifier = ">=2025.1.2" },
     { name = "xgboost-cpu", specifier = ">=3.1.2" },
@@ -731,6 +736,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -1010,6 +1024,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1186,6 +1212,69 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1237,6 +1326,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/4b/e7beb6bbd49f6bae727a12b270a2654d13c397576d25bd6786e47033300f/matplotlib-3.10.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:595ba4d8fe983b88f0eec8c26a241e16d6376fe1979086232f481f8f3f67494c", size = 9614011, upload-time = "2025-12-10T22:56:33.85Z" },
     { url = "https://files.pythonhosted.org/packages/7c/e6/76f2813d31f032e65f6f797e3f2f6e4aab95b65015924b1c51370395c28a/matplotlib-3.10.8-cp314-cp314t-win_amd64.whl", hash = "sha256:25d380fe8b1dc32cf8f0b1b448470a77afb195438bafdf1d858bfb876f3edf7b", size = 8362801, upload-time = "2025-12-10T22:56:36.107Z" },
     { url = "https://files.pythonhosted.org/packages/5d/49/d651878698a0b67f23aa28e17f45a6d6dd3d3f933fa29087fa4ce5947b5a/matplotlib-3.10.8-cp314-cp314t-win_arm64.whl", hash = "sha256:113bb52413ea508ce954a02c10ffd0d565f9c3bc7f2eddc27dfe1731e71c7b5f", size = 8192560, upload-time = "2025-12-10T22:56:38.008Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1297,6 +1395,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/d5/e7685c66b7f011c73cd746127f986358a26c642a4e4a1aa5ab51481b6586/netcdf4-1.7.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31a2318305de6831a18df25ad0df9f03b6d68666af0356d4f6057d66c02ffeb6", size = 10255032, upload-time = "2026-01-05T02:27:31.744Z" },
     { url = "https://files.pythonhosted.org/packages/a6/14/7506738bb6c8bc373b01e5af8f3b727f83f4f496c6b108490ea2609dc2cf/netcdf4-1.7.4-cp314-cp314t-win_amd64.whl", hash = "sha256:6c4a0aa9446c3a616ef3be015b629dc6173643f8b09546de26a4e40e272cd1ed", size = 22289653, upload-time = "2026-01-05T02:27:34.294Z" },
     { url = "https://files.pythonhosted.org/packages/af/2e/39d5e9179c543f2e6e149a65908f83afd9b6d64379a90789b323111761db/netcdf4-1.7.4-cp314-cp314t-win_arm64.whl", hash = "sha256:034220887d48da032cb2db5958f69759dbb04eb33e279ec6390571d4aea734fe", size = 2531682, upload-time = "2026-01-05T02:27:37.062Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2386,6 +2493,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
 name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2455,6 +2571,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tailwind-colors"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2504,6 +2632,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d2dd0f2c5f7ccbddaf34cade0deaf476808368f902b9cdb7f36a2ab42301bc0e", upload-time = "2026-06-17T15:44:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", upload-time = "2026-06-17T15:44:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", upload-time = "2026-06-17T15:44:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", upload-time = "2026-06-17T15:44:24Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.1+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version < '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:900b253fc8c739bebffb63d7f75abff4cd53d79947265a00c16cb53b68ecdb91", upload-time = "2026-06-18T01:57:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d1620bc7bcf8087f3e48821b5db994a03e32ddb083d58c000b8e032f8a6e2d15", upload-time = "2026-06-18T01:57:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ae4bb28409f5370852bd71af221066236c38d647f780d9b0a7240c330a9c12df", upload-time = "2026-06-18T01:57:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:51c6c6e26eaa0d64ed439ebdc9ce3b8cc2d5cfcc7cdd4e72f17831d80886b7f4", upload-time = "2026-06-18T01:57:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:4ca206a35f2aeba7da944a69ef857103358e8d4bc6b06b49b9e554dcfa57777d", upload-time = "2026-06-18T01:57:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8d47e0cfc59679d4e367646c3df4cf433c7d1595b31307e0e7b2391c58ca2160", upload-time = "2026-06-18T01:57:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:77d049968c7817456dbdebf0aadcac0813e302218b0e857a8723463331339d55", upload-time = "2026-06-18T01:57:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:06d13c354df07953ae0d150da22a071496cbbedd22d1b644961813c0f0fc3b23", upload-time = "2026-06-18T01:58:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:ef228ec70f5e73762c213f145c0fdb672e5770a6de760801c58b933b0d5b6957", upload-time = "2026-06-18T01:58:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b9ad70d0a300d6bd883fffc153a6c0f9bc64bf4190519aeeed0373807bffbcc", upload-time = "2026-06-18T01:58:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:618120d79360688595e61162147d37e1d69fc3f2e13d60584a1eb6a74c74735a", upload-time = "2026-06-18T01:58:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:6354069774ce2d9c26d6d8612fc252586428467b7e4ced7c8bbbfb961fafb783", upload-time = "2026-06-18T01:58:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:0706eb7b53c4b1381b2acc418f6d89d6ed18a308677125ced7ca30519c57dc42", upload-time = "2026-06-18T01:58:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:21ed774c10a0fd24ab2cfaabfa98a9260fc28d518946c98c0151b6e447730250", upload-time = "2026-06-18T01:58:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e3c3b5c275dd57cff1aa34a0ab8f84beab8976c63c8dc1d84f29430eac0590ea", upload-time = "2026-06-18T01:58:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:03094411b20e85a221125a332211d59c099dc556afb1423e04193fcf1b4c1cbd", upload-time = "2026-06-18T01:58:52Z" },
 ]
 
 [[package]]

--- a/demandcast/uv.lock
+++ b/demandcast/uv.lock
@@ -637,12 +637,16 @@ dependencies = [
     { name = "shapely" },
     { name = "tailwind-colors" },
     { name = "timezonefinder" },
-    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "xarray" },
     { name = "xgboost-cpu" },
     { name = "xlrd" },
+]
+
+[package.optional-dependencies]
+lstm = [
+    { name = "torch", version = "2.12.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -686,12 +690,13 @@ requires-dist = [
     { name = "shapely", specifier = ">=2.0.7" },
     { name = "tailwind-colors", specifier = ">=1.3.0" },
     { name = "timezonefinder", specifier = ">=6.5.9" },
-    { name = "torch", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "extra == 'lstm'", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "xarray", specifier = ">=2025.1.2" },
     { name = "xgboost-cpu", specifier = ">=3.1.2" },
     { name = "xlrd", specifier = ">=2.0.1" },
 ]
+provides-extras = ["lstm"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/demandcast/validate.py
+++ b/demandcast/validate.py
@@ -13,6 +13,7 @@ import logging
 import os
 from typing import Optional
 
+import ml_models.lstm
 import ml_models.xgboost
 import pandas
 import utils.config
@@ -223,6 +224,30 @@ def run_model_validation(
 
         # Make predictions.
         predictions = ml_models.xgboost.predict(model, prepared_dataset)
+
+    elif algorithm.lower() == "lstm":
+        # Get the trained model path.
+        trained_model_path = utils.ml.get_trained_model_path(
+            model_path, algorithm.lower(), extension=".pt"
+        )
+
+        # Load the trained model.
+        model = ml_models.lstm.load(trained_model_path)
+
+        # Check that the model was trained with the same features of the
+        # prepared dataset.
+        data_features = prepared_dataset["training"][
+            "features"
+        ].columns.tolist()
+        model_features = model.feature_names_in_.tolist()
+        if data_features != model_features:
+            raise ValueError(
+                "The features used in the prepared dataset do not match "
+                "those used during model training."
+            )
+
+        # Make predictions.
+        predictions = ml_models.lstm.predict(model, prepared_dataset)
 
     else:
         raise ValueError(f"Unsupported algorithm: {algorithm}")

--- a/webpage/docs/ML.md
+++ b/webpage/docs/ML.md
@@ -145,6 +145,37 @@ The `predict()` function supports two calling modes that mirror the XGBoost inte
 - **Categorical features treated as numeric**: The LSTM receives all features as `float32` tensors. Categorical features (hour of day, month, weekend flag, temperature rank) are passed as integer-encoded numbers, the same encoding used by XGBoost. The LSTM does not apply embedding layers to these features.
 - **Optional algorithm**: LSTM is not the default algorithm. The default is XGBoost, selected by setting `algorithm: XGBoost` in `ml_config.yaml`. To switch to LSTM, set `algorithm: LSTM`.
 
+### Benchmark Results
+
+To compare the two algorithms under identical conditions, both were trained and validated on a benchmark dataset covering three countries (Denmark, Austria, Portugal) with electricity demand, temperature, population, and GDP data for 2021-2023. The most recent year of each entity was reserved as the testing set (`reserve_testing_set: true`), consistent with the temporal splitting described above.
+
+**Per-entity testing set MAPE:**
+
+| Entity | XGBoost | LSTM |
+|---|---|---|
+| DNK | 0.0931 | 0.1555 |
+| AUT | 0.1085 | 0.1754 |
+| PRT | 0.0869 | 0.1634 |
+
+**Overall testing set MAPE:**
+
+| Metric | XGBoost | LSTM |
+|---|---|---|
+| Mean | 0.0962 | 0.1648 |
+| Median | 0.0931 | 0.1634 |
+
+On this benchmark, XGBoost outperforms LSTM by a wide margin on every entity. This should not be read as general evidence that sequence models are unsuited to load forecasting — the result is best explained by the small size of this particular benchmark. With only three entities and a few years of hourly data each, there are too few independent sequences for the LSTM to learn its recurrent weights across a `n_timesteps=24` lookback window without underfitting. The training-set MAPE supports this reading: it is close to the testing-set MAPE for LSTM (~0.166–0.167 training vs ~0.155–0.175 testing), rather than substantially lower as would be expected if the model were overfitting. XGBoost, by contrast, benefits from engineered temporal features (hour-of-day, month, weekend flag) that hand it context an LSTM must otherwise learn implicitly from data volume it does not yet have here.
+
+**XGBoost remains the recommended default algorithm** for DemandCast, and this benchmark supports that recommendation for datasets of comparable size. LSTM should be treated as an optional alternative, best suited to future benchmarks with more entities and longer historical spans, where enough sequential data exists for the recurrent architecture to learn temporal dependencies without underfitting. Users experimenting with the LSTM algorithm on small datasets should expect it to underperform XGBoost until dataset scale increases substantially.
+
+**Benchmark configuration:**
+
+- Entities: DNK, AUT, PRT
+- Years: 2021-2023
+- Test set: most recent year per entity (`reserve_testing_set: true`)
+- LSTM: default hyperparameters (`n_timesteps=24`, `n_units=32`, `n_layers=1`, `epochs=5`)
+- XGBoost: default hyperparameters (see [XGBoost Configuration](#xgboost-configuration))
+
 ## Training and Validation
 
 The machine learning pipeline in DemandCast is managed through several Python scripts located in the `demandcast/` directory. Each script utilizes a configuration file to specify parameters such as data paths, model settings, and evaluation metrics. All scripts accept only the path to a configuration file:

--- a/webpage/docs/ML.md
+++ b/webpage/docs/ML.md
@@ -87,6 +87,64 @@ The XGBoost-specific configuration is specified in `demandcast/config/xgboost_co
 - Categorical feature support enablement
 - Evaluation metric (Mean Absolute Percentage Error - MAPE)
 
+## LSTM Algorithm
+
+Long Short-Term Memory (LSTM) networks extend DemandCast's forecasting toolkit as an alternative to XGBoost, bringing a sequence-aware architecture that is well-suited to the hourly, temporally ordered structure of electricity demand data.
+
+### Motivation
+
+The motivation for including an LSTM model builds on peer-reviewed work that benchmarks deep sequence models against classical time-series and gradient boosting approaches for energy demand forecasting (e.g. [Ul Rehman and Iqbal, 2025](https://doi.org/10.1186/s42162-025-00587-5)). Research comparing LSTM, Seq2Seq, and Prophet on smart-meter data demonstrates that LSTM networks consistently outperform statistical baselines when capturing daily and weekly periodicities in disaggregated load profiles. Electricity demand is an inherently sequential signal: the load at any given hour is influenced by the hours immediately preceding it—morning warm-up, evening peak, overnight trough—and an architecture that learns these temporal dependencies directly from the input sequence is a natural complement to XGBoost. Where XGBoost sees each row as an independent observation and relies on engineered temporal features (hour-of-day, month, weekend flag) to encode context, the LSTM models that context implicitly through its recurrent hidden state. Together, the two algorithms offer a gradient-boosting baseline and a sequence-learning alternative that can be compared under identical evaluation protocols.
+
+### Architecture
+
+The LSTM implementation in DemandCast (`ml_models/lstm.py`) is built on PyTorch's `nn.LSTM` module paired with a single linear output layer. The network accepts input tensors of shape `(batch, n_timesteps, n_features)`, passes them through one or more stacked LSTM layers, and projects the final hidden state to a scalar prediction via `nn.Linear(n_units, 1)`. Dropout can be applied between stacked layers when `n_layers > 1`.
+
+The `LSTMRegressor` class wraps this network in a scikit-learn-compatible estimator (`BaseEstimator`, `RegressorMixin`), giving it `fit()` and `predict()` methods that accept `pandas.DataFrame` and `pandas.Series` inputs. This interface allows the model to be passed directly to `sklearn.model_selection.cross_validate` and `LeaveOneGroupOut`, using the same evaluation infrastructure as XGBoost without modification.
+
+Sequence construction is entity-aware. Each training or inference sample requires a lookback window of `n_timesteps` consecutive rows. Rather than drawing rows across entity (country or region) boundaries, the sequence builder identifies contiguous runs of the same entity label from the `"group"` column of the prepared dataset and zero-pads the leading edge of each new run. This ensures that predictions for the first hours of a new entity are not contaminated by data from the preceding entity in the DataFrame.
+
+### LSTM Configuration
+
+The LSTM-specific configuration is specified in `demandcast/config/lstm_config.yaml`. All parameters are required; the values listed below are the defaults.
+
+| Name | Type | Default | Required / Optional | Description |
+|---|---|---|---|---|
+| `n_timesteps` | `int` | `24` | Required | Lookback window length in timesteps. Each prediction draws on the preceding `n_timesteps` rows of the same entity. |
+| `n_units` | `int` | `32` | Required | Number of LSTM hidden units per layer. Smaller values train faster on CPU. |
+| `n_layers` | `int` | `1` | Required | Number of stacked LSTM layers. Dropout only takes effect when `n_layers > 1`. |
+| `dropout` | `float` | `0.0` | Required | Dropout rate applied between LSTM layers. Only meaningful when `n_layers > 1`. |
+| `epochs` | `int` | `5` | Required | Number of full passes over the training data. Increase for better accuracy at the cost of training time. |
+| `batch_size` | `int` | `256` | Required | Mini-batch size used for both training and inference. |
+| `learning_rate` | `float` | `0.001` | Required | Adam optimiser learning rate. |
+| `random_state` | `int` | `42` | Required | Random seed passed to `torch.manual_seed` for reproducibility. |
+
+To use the LSTM algorithm, set `algorithm: LSTM` in `ml_config.yaml`.
+
+### Dependencies
+
+The LSTM model requires `torch>=2.0.0`, which is included in `demandcast/pyproject.toml`. CPU-only installation is sufficient for the default configuration; no GPU is required. Training time on CPU with the default hyperparameters is comparable to XGBoost for typical dataset sizes.
+
+### Input and Output Format
+
+The LSTM model consumes the same `prepared_dataset` structure produced by `utils.ml.prepare_dataset` as XGBoost. Each split (`"training"`, `"validation"`, `"testing"`) is a dictionary containing:
+
+- `"features"` — `pandas.DataFrame` of input features
+- `"target"` — `pandas.Series` of target values
+- `"group"` — `pandas.Series` of entity labels (used for entity-boundary sequence construction)
+- `"time"` — `pandas.Series` of UTC timestamps
+- `"scaling_factor"` — `pandas.Series` of per-row scaling factors
+
+The `predict()` function supports two calling modes that mirror the XGBoost interface:
+
+- **Single-dataset mode**: if `prepared_dataset` contains a `"features"` key at the top level, `predict()` returns a bare `pandas.Series` of predictions.
+- **Multi-split mode**: if `prepared_dataset` contains `"training"`, `"validation"`, and/or `"testing"` keys, `predict()` returns a `dict[str, pandas.Series]` mapping each split name to its predictions.
+
+### Assumptions and Limitations
+
+- **Zero-padding for the initial lookback**: For the first `n_timesteps - 1` rows of each entity, the lookback window cannot be filled from historical data. These positions are zero-padded, which means the model's effective context is shorter at the start of each entity's time series. This is standard practice for sequence models applied to short or boundary-constrained series.
+- **Categorical features treated as numeric**: The LSTM receives all features as `float32` tensors. Categorical features (hour of day, month, weekend flag, temperature rank) are passed as integer-encoded numbers, the same encoding used by XGBoost. The LSTM does not apply embedding layers to these features.
+- **Optional algorithm**: LSTM is not the default algorithm. The default is XGBoost, selected by setting `algorithm: XGBoost` in `ml_config.yaml`. To switch to LSTM, set `algorithm: LSTM`.
+
 ## Training and Validation
 
 The machine learning pipeline in DemandCast is managed through several Python scripts located in the `demandcast/` directory. Each script utilizes a configuration file to specify parameters such as data paths, model settings, and evaluation metrics. All scripts accept only the path to a configuration file:


### PR DESCRIPTION
## Summary

Adds a PyTorch LSTM model as an optional alternative to XGBoost for hourly electricity demand forecasting, addressing issue #133. Submitted as a draft because all items on the requested checklist are now complete, including the XGBoost-vs-LSTM benchmark on real DemandCast data.

## Checklist against @eantonini's requested items

- [x] Same public model interface as xgboost.py (train, predict, save, load, get_initialized_model)
- [x] Validated lstm_config.yaml following the existing configuration pattern (Pydantic ConfigModel, REQUIRED/OPTIONAL inline comments)
- [x] Unit tests consistent with the current testing approach (18 tests in tests/test_lstm.py covering fit/predict, entity-aware sequence construction, group boundary enforcement, save/load round-trip; 2 new tests in tests/test_ml.py; all passing)
- [x] Documentation in webpage/docs/ML.md: full LSTM Algorithm section covering motivation, architecture, config parameter table, dependencies, input/output format, and assumptions/limitations, with citation to the peer-reviewed methodology (Ul Rehman and Iqbal, 2025, doi:10.1186/s42162-025-00587-5)
- [x] Benchmark against XGBoost on real DemandCast data (DNK, AUT, PRT, 2021-2023) using identical train/validate/test logic and MAPE evaluation metric
- [x] LSTM kept as optional — XGBoost remains the default algorithm
- [x] Reasonable CPU-friendly defaults (n_timesteps=24, n_units=32, epochs=5) confirmed to train in under 15 minutes on CPU

## Benchmark results

Both algorithms trained and validated on Denmark, Austria, and Portugal (2021-2023) under identical conditions. Testing set MAPE:

| Entity | XGBoost | LSTM |
|--------|---------|------|
| DNK | 0.0931 | 0.1555 |
| AUT | 0.1085 | 0.1754 |
| PRT | 0.0869 | 0.1634 |
| Mean | 0.0962 | 0.1648 |

XGBoost outperforms LSTM on this benchmark. The most likely explanation is dataset scale: with only three entities and two years of hourly data, there are too few independent sequences for the LSTM to learn its recurrent weights without underfitting (training and testing MAPE are close for LSTM, ruling out overfitting). XGBoost benefits from the engineered temporal features that hand it context the LSTM must learn implicitly from data volume it does not yet have here. The full analysis is in the Benchmark Results section of ML.md.

XGBoost remains the recommended default. LSTM is included as an optional alternative for users who want to explore sequence models on larger datasets.

## Additional changes in this PR

Two small independent fixes included alongside the LSTM feature:

UTF-8 encoding fix: five places in utils/ (config.py x2, entities.py, ml.py, uploader.py) opened YAML config files without explicit encoding, falling back to the Windows locale default (cp1252). One config file contains a UTF-8 character (Kantō in tepco.yaml) that cp1252 cannot decode, causing a crash on Windows. Added encoding="utf-8" to all five. Full test suite still passes.

.gitignore: added .claude/ to prevent local Claude Code scaffolding from being accidentally committed.

## Dependencies

torch>=2.0.0 added to pyproject.toml with the PyTorch CPU wheel index. CPU-only installation is sufficient. No GPU